### PR TITLE
Move message and state types to separate files

### DIFF
--- a/examples/Online/DY.Online.Data.fst
+++ b/examples/Online/DY.Online.Data.fst
@@ -1,0 +1,135 @@
+module DY.Online.Data
+
+open Comparse
+open DY.Core
+open DY.Lib
+
+/// Here, we define the abstract types for the "Online?" Protocol:
+///
+/// A -> B: enc{Ping (A, n_A)}_B
+/// B -> A: enc{Ack n_A}_A
+///
+/// (They are the same as for the simple 2 message protocol)
+
+
+
+(*** Message Type ***)
+
+/// for each of the two messages we define an abstract message type
+
+[@@ with_bytes bytes] // ignore this line for now
+type ping_t = {
+  p_alice: principal;
+  p_n_a : bytes;
+}
+
+[@@ with_bytes bytes] // ignore this line for now
+type ack = {
+  a_n_a : bytes;
+}
+
+/// the overall abstract message type
+/// (consisting of constructors for the two messages
+/// and using the above abstract types for each of them)
+
+[@@ with_bytes bytes] // ignore this line for now
+type message =
+  | Ping: (ping:ping_t) -> message
+  | Ack: (ack:ack) -> message
+
+
+/// We use Comparse to generate the corresponding message formats.
+/// I.e., we don't need to write parsing and serializing by hand
+///
+/// for this we need the `[@@ with_bytes bytes]` annotation for the message types above
+///
+/// We are not going into the details of how Comparse works.
+
+
+/// We let Comparse generate a parser `ps_ping` for the abstract `ping` type
+%splice [ps_ping_t] (gen_parser (`ping_t))
+
+%splice [ps_ack] (gen_parser (`ack))
+
+%splice [ps_message] (gen_parser (`message))
+
+/// With the above parsers, we can make our `message` type an instance of
+/// Comparse's `parseable_serializeable` class.
+/// Again, the details are not important here,
+/// but this is the step that enables us to call
+/// `parse message buff` and `serialize message msg`
+/// to translate between bytes and our abstract message type.
+instance parseable_serializeable_bytes_message: parseable_serializeable bytes message = mk_parseable_serializeable ps_message
+
+
+(*** State Type ***)
+
+/// As for the messages we define abstract state types
+/// for the three states stored by Alice and Bob after each step of the protocol.
+
+[@@ with_bytes bytes]
+type sent_ping = {
+  sp_bob : principal;
+  sp_n_a : bytes;
+}
+
+[@@ with_bytes bytes]
+type sent_ack = {
+  sa_alice: principal;
+  sa_n_a : bytes;
+}
+
+[@@ with_bytes bytes]
+type received_ack = {
+  ra_bob : principal;
+  ra_n_a : bytes;
+}
+
+[@@ with_bytes bytes]
+type state = 
+  | SentPing: (ping:sent_ping) -> state
+  | SentAck: (ack:sent_ack) -> state
+  | ReceivedAck: (rack:received_ack) -> state
+
+/// As for messages, we use Comparse to generate
+/// a parser and serializer for our abstract state type.
+
+%splice [ps_sent_ping] (gen_parser (`sent_ping))
+%splice [ps_sent_ack] (gen_parser (`sent_ack))
+%splice [ps_received_ack] (gen_parser (`received_ack))
+%splice [ps_state] (gen_parser (`state))
+
+/// Now, we can call
+/// `parse state buff` and `serialize state st`
+/// to translate between bytes and the abstract state type.
+instance parseable_serializeable_bytes_state: parseable_serializeable bytes state = mk_parseable_serializeable ps_state
+
+/// We tag our protocol level states,
+/// so that they are distinguishable from any internal DY* states. 
+
+instance local_state_state: local_state state = {
+  tag = "P.State";
+  format = parseable_serializeable_bytes_state;
+}
+
+
+(*** PKI ***)
+
+/// For en-/de-cryption we assume some PKI.
+/// I.e., every participant has some private decryption keys
+/// and some public encryption keys from other participants.
+/// All private keys of a participant will be stored in one session
+/// and all public keys that the participant knows will be stored in another session.
+/// For each participant, we collect both these session IDs in a global record.
+
+type global_sess_ids = {
+  pki: state_id;
+  private_keys: state_id;
+}
+
+/// Similarly as for states,
+/// we tag the keys that are used on the protocol level,
+/// so that they can not be confused with other keys.
+/// (TODO: rephrase this)
+
+let key_tag = "P.Key"

--- a/examples/Online/DY.Online.Data.fst
+++ b/examples/Online/DY.Online.Data.fst
@@ -11,21 +11,19 @@ open DY.Lib
 ///
 /// (They are the same as for the simple 2 message protocol)
 
-
-
 (*** Message Type ***)
 
 /// for each of the two messages we define an abstract message type
 
 [@@ with_bytes bytes] // ignore this line for now
 type ping_t = {
-  p_alice: principal;
-  p_n_a : bytes;
+  alice: principal;
+  n_a : bytes;
 }
 
 [@@ with_bytes bytes] // ignore this line for now
-type ack = {
-  a_n_a : bytes;
+type ack_t = {
+  n_a : bytes;
 }
 
 /// the overall abstract message type
@@ -33,9 +31,9 @@ type ack = {
 /// and using the above abstract types for each of them)
 
 [@@ with_bytes bytes] // ignore this line for now
-type message =
-  | Ping: (ping:ping_t) -> message
-  | Ack: (ack:ack) -> message
+type message_t =
+  | Ping: (ping:ping_t) -> message_t
+  | Ack: (ack:ack_t) -> message_t
 
 
 /// We use Comparse to generate the corresponding message formats.
@@ -46,12 +44,15 @@ type message =
 /// We are not going into the details of how Comparse works.
 
 
-/// We let Comparse generate a parser `ps_ping` for the abstract `ping` type
+/// We let Comparse generate a parser `ps_ping_t` for the abstract `ping_t` type
+
 %splice [ps_ping_t] (gen_parser (`ping_t))
 
-%splice [ps_ack] (gen_parser (`ack))
+/// ... and the same for the other abstract message types
 
-%splice [ps_message] (gen_parser (`message))
+%splice [ps_ack_t] (gen_parser (`ack_t))
+
+%splice [ps_message_t] (gen_parser (`message_t))
 
 /// With the above parsers, we can make our `message` type an instance of
 /// Comparse's `parseable_serializeable` class.
@@ -59,7 +60,8 @@ type message =
 /// but this is the step that enables us to call
 /// `parse message buff` and `serialize message msg`
 /// to translate between bytes and our abstract message type.
-instance parseable_serializeable_bytes_message: parseable_serializeable bytes message = mk_parseable_serializeable ps_message
+
+instance parseable_serializeable_bytes_message_t: parseable_serializeable bytes message_t = mk_parseable_serializeable ps_message_t
 
 
 (*** State Type ***)
@@ -68,49 +70,51 @@ instance parseable_serializeable_bytes_message: parseable_serializeable bytes me
 /// for the three states stored by Alice and Bob after each step of the protocol.
 
 [@@ with_bytes bytes]
-type sent_ping = {
-  sp_bob : principal;
-  sp_n_a : bytes;
+type sent_ping_t = {
+  bob : principal;
+  n_a : bytes;
 }
 
 [@@ with_bytes bytes]
-type sent_ack = {
-  sa_alice: principal;
-  sa_n_a : bytes;
+type sent_ack_t = {
+  alice: principal;
+  n_a : bytes;
 }
 
 [@@ with_bytes bytes]
-type received_ack = {
-  ra_bob : principal;
-  ra_n_a : bytes;
+type received_ack_t = {
+  bob : principal;
+  n_a : bytes;
 }
 
 [@@ with_bytes bytes]
-type state = 
-  | SentPing: (ping:sent_ping) -> state
-  | SentAck: (ack:sent_ack) -> state
-  | ReceivedAck: (rack:received_ack) -> state
+type state_t = 
+  | SentPing: (ping:sent_ping_t) -> state_t
+  | SentAck: (ack:sent_ack_t) -> state_t
+  | ReceivedAck: (rack:received_ack_t) -> state_t
 
 /// As for messages, we use Comparse to generate
-/// a parser and serializer for our abstract state type.
+/// a parser and serializer for our abstract state types.
 
-%splice [ps_sent_ping] (gen_parser (`sent_ping))
-%splice [ps_sent_ack] (gen_parser (`sent_ack))
-%splice [ps_received_ack] (gen_parser (`received_ack))
-%splice [ps_state] (gen_parser (`state))
+%splice [ps_sent_ping_t] (gen_parser (`sent_ping_t))
+%splice [ps_sent_ack_t] (gen_parser (`sent_ack_t))
+%splice [ps_received_ack_t] (gen_parser (`received_ack_t))
+%splice [ps_state_t] (gen_parser (`state_t))
 
 /// Now, we can call
 /// `parse state buff` and `serialize state st`
 /// to translate between bytes and the abstract state type.
-instance parseable_serializeable_bytes_state: parseable_serializeable bytes state = mk_parseable_serializeable ps_state
+
+instance parseable_serializeable_bytes_state_t: parseable_serializeable bytes state_t = mk_parseable_serializeable ps_state_t
 
 /// We tag our protocol level states,
 /// so that they are distinguishable from any internal DY* states. 
 
-instance local_state_state: local_state state = {
+instance local_state_state: local_state state_t = {
   tag = "P.State";
-  format = parseable_serializeable_bytes_state;
+  format = parseable_serializeable_bytes_state_t;
 }
+
 
 
 (*** PKI ***)

--- a/examples/Online/DY.Online.Protocol.fst
+++ b/examples/Online/DY.Online.Protocol.fst
@@ -7,135 +7,26 @@ open DY.Lib
 open DY.Simplified
 open DY.Extend
 
-/// The "Online?" protocol
-/// 
-/// An extension of the simple Two Message protocol:
+open DY.Online.Data
+
+/// Here we define the DY* mode of the "Online?" protocol,
+/// an extension of the simple Two Message protocol:
 /// the two messages are now (asymmetrically) encrypted
 ///
 /// A -> B: enc{Ping (A, n_A)}_B
 /// B -> A: enc{Ack n_A}_A
-
-(*** Message Type ***)
-
-/// for each of the two messages we define an abstract message type
-
-[@@ with_bytes bytes] // ignore this line for now
-type ping_t = {
-  p_alice: principal;
-  p_n_a : bytes;
-}
-
-[@@ with_bytes bytes] // ignore this line for now
-type ack = {
-  a_n_a : bytes;
-}
-
-/// the overall abstract message type
-/// (consisting of constructors for the two messages
-/// and using the above abstract types for each of them)
-
-[@@ with_bytes bytes] // ignore this line for now
-type message =
-  | Ping: (ping:ping_t) -> message
-  | Ack: (ack:ack) -> message
-
-
-/// We use Comparse to generate the corresponding message formats.
-/// I.e., we don't need to write parsing and serializing by hand
 ///
-/// for this we need the `[@@ with_bytes bytes]` annotation for the message types above
+/// The model consists of 3 functions,
+/// one for each protocol step
+/// (just as for the simple two message protocol):
+/// 1. Alice sends the Ping to Bob (`send_ping`)
+/// 2. Bob receives the Ping and replies with the Ack (`receive_ping_and_send_ack`)
+/// 3. Alice receives the Ack (`receive_ack`)
 ///
-/// We are not going into the details of how Comparse works.
+/// Additionally, there are two helper functions
+/// for steps 2 and 3 (`decode_ping` and `decode_ack`).
 
-
-/// We let Comparse generate a parser `ps_ping` for the abstract `ping` type
-%splice [ps_ping_t] (gen_parser (`ping_t))
-
-%splice [ps_ack] (gen_parser (`ack))
-
-%splice [ps_message] (gen_parser (`message))
-
-/// With the above parsers, we can make our `message` type an instance of
-/// Comparse's `parseable_serializeable` class.
-/// Again, the details are not important here,
-/// but this is the step that enables us to call
-/// `parse message buff` and `serialize message msg`
-/// to translate between bytes and our abstract message type.
-instance parseable_serializeable_bytes_message: parseable_serializeable bytes message = mk_parseable_serializeable ps_message
-
-
-(*** State Type ***)
-
-/// As for the messages we define abstract state types
-/// for the three states stored by Alice and Bob after each step of the protocol.
-
-[@@ with_bytes bytes]
-type sent_ping = {
-  sp_bob : principal;
-  sp_n_a : bytes;
-}
-
-[@@ with_bytes bytes]
-type sent_ack = {
-  sa_alice: principal;
-  sa_n_a : bytes;
-}
-
-[@@ with_bytes bytes]
-type received_ack = {
-  ra_bob : principal;
-  ra_n_a : bytes;
-}
-
-[@@ with_bytes bytes]
-type state = 
-  | SentPing: (ping:sent_ping) -> state
-  | SentAck: (ack:sent_ack) -> state
-  | ReceivedAck: (rack:received_ack) -> state
-
-/// As for messages, we use Comparse to generate
-/// a parser and serializer for our abstract state type.
-
-%splice [ps_sent_ping] (gen_parser (`sent_ping))
-%splice [ps_sent_ack] (gen_parser (`sent_ack))
-%splice [ps_received_ack] (gen_parser (`received_ack))
-%splice [ps_state] (gen_parser (`state))
-
-/// Now, we can call
-/// `parse state buff` and `serialize state st`
-/// to translate between bytes and the abstract state type.
-instance parseable_serializeable_bytes_state: parseable_serializeable bytes state = mk_parseable_serializeable ps_state
-
-/// We tag our protocol level states,
-/// so that they are distinguishable from any internal DY* states. 
-
-instance local_state_state: local_state state = {
-  tag = "P.State";
-  format = parseable_serializeable_bytes_state;
-}
-
-(*** PKI ***)
-
-/// For en-/de-cryption we assume some PKI.
-/// I.e., every participant has some private decryption keys
-/// and some public encryption keys from other participants.
-/// All private keys of a participant will be stored in one session
-/// and all public keys that the participant knows will be stored in another session.
-/// For each participant, we collect both these session IDs in a global record.
-
-type global_sess_ids = {
-  pki: state_id;
-  private_keys: state_id;
-}
-
-/// Similarly as for states,
-/// we tag the keys that are used on the protocol level,
-/// so that they can not be confused with other keys.
-/// (TODO: rephrase this)
-
-let key_tag = "P.Key"
-
-(*** The Protocol ***)
+(*** Sending the Ping ***)
 
 /// Alice sends the first message to Bob:
 /// * Alice generates a new nonce [n_a]
@@ -163,6 +54,9 @@ let send_ping alice bob keys_sid =
   let* sid = start_new_session alice ping_state in
 
   return (Some (sid, msg_ts))
+
+
+(*** Replying to a Ping with an Ack ***)
 
 
 /// Bob receives the first messages and replies:
@@ -219,6 +113,9 @@ let receive_ping_and_send_ack bob global_sids msg_ts =
   let* sess_id = start_new_session bob (SentAck {sa_alice = alice; sa_n_a = n_a}) in
   
   return (Some (sess_id, ack_ts))
+
+
+(*** Receiving an Ack ***)
 
 
 /// Alice receives the reply from Bob:

--- a/examples/Online/DY.Online.Run.Printing.fst
+++ b/examples/Online/DY.Online.Run.Printing.fst
@@ -3,7 +3,8 @@ module DY.Online.Run.Printing
 open DY.Core
 open DY.Lib
 open Comparse
-open DY.Online.Protocol
+
+open DY.Online.Data
 
 /// Helper functions for trace printing.
 /// Here we define how our abstract message and state types

--- a/examples/Online/DY.Online.Run.Printing.fst
+++ b/examples/Online/DY.Online.Run.Printing.fst
@@ -13,17 +13,17 @@ open DY.Online.Data
 
 val message_to_string: bytes -> option string
 let message_to_string b =
-  match? parse message b with
-  | Ping p -> Some (Printf.sprintf "Ping [name = (%s), n_a = (%s)]" (p.p_alice) (bytes_to_string p.p_n_a))
-  | Ack a -> Some (Printf.sprintf "Ping [n_a = (%s)]" (bytes_to_string a.a_n_a))
+  match? parse message_t b with
+  | Ping p -> Some (Printf.sprintf "Ping [name = (%s), n_a = (%s)]" (p.alice) (bytes_to_string p.n_a))
+  | Ack a -> Some (Printf.sprintf "Ping [n_a = (%s)]" (bytes_to_string a.n_a))
 
 
 val state_to_string: bytes -> option string
 let state_to_string b =
-  match? parse state b with
-  | SentPing p -> Some (Printf.sprintf "SentPing [to = (%s), n_a = (%s)]" p.sp_bob (bytes_to_string p.sp_n_a))
-  | SentAck a -> Some (Printf.sprintf "SentAck [to = (%s), n_a = (%s)]" a.sa_alice (bytes_to_string a.sa_n_a))
-  | ReceivedAck r -> Some (Printf.sprintf "ReceivedAck [from = (%s), n_a = (%s)]" r.ra_bob (bytes_to_string r.ra_n_a))
+  match? parse state_t b with
+  | SentPing p -> Some (Printf.sprintf "SentPing [to = (%s), n_a = (%s)]" p.bob (bytes_to_string p.n_a))
+  | SentAck a -> Some (Printf.sprintf "SentAck [to = (%s), n_a = (%s)]" a.alice (bytes_to_string a.n_a))
+  | ReceivedAck r -> Some (Printf.sprintf "ReceivedAck [from = (%s), n_a = (%s)]" r.bob (bytes_to_string r.n_a))
 
 
 

--- a/examples/Online/DY.Online.Run.fst
+++ b/examples/Online/DY.Online.Run.fst
@@ -4,6 +4,7 @@ open DY.Core
 open DY.Lib
 
 open DY.Online.Run.Printing
+open DY.Online.Data
 open DY.Online.Protocol
 
 /// Here, we print the trace after a successful run of the Two Message protocol.

--- a/examples/Online_with_secrecy/DY.OnlineS.Data.fst
+++ b/examples/Online_with_secrecy/DY.OnlineS.Data.fst
@@ -1,0 +1,139 @@
+module DY.OnlineS.Data
+
+open Comparse
+open DY.Core
+open DY.Lib
+
+/// Here, we define the abstract types for the "Online?" Protocol:
+///
+/// A -> B: enc{Ping (A, n_A)}_B
+/// B -> A: enc{Ack n_A}_A
+///
+/// (They are the same as for the simple 2 message protocol)
+
+(*** Message Type ***)
+
+/// for each of the two messages we define an abstract message type
+
+[@@ with_bytes bytes] // ignore this line for now
+type ping_t = {
+  alice: principal;
+  n_a : bytes;
+}
+
+[@@ with_bytes bytes] // ignore this line for now
+type ack_t = {
+  n_a : bytes;
+}
+
+/// the overall abstract message type
+/// (consisting of constructors for the two messages
+/// and using the above abstract types for each of them)
+
+[@@ with_bytes bytes] // ignore this line for now
+type message_t =
+  | Ping: (ping:ping_t) -> message_t
+  | Ack: (ack:ack_t) -> message_t
+
+
+/// We use Comparse to generate the corresponding message formats.
+/// I.e., we don't need to write parsing and serializing by hand
+///
+/// for this we need the `[@@ with_bytes bytes]` annotation for the message types above
+///
+/// We are not going into the details of how Comparse works.
+
+
+/// We let Comparse generate a parser `ps_ping_t` for the abstract `ping_t` type
+
+%splice [ps_ping_t] (gen_parser (`ping_t))
+
+/// ... and the same for the other abstract message types
+
+%splice [ps_ack_t] (gen_parser (`ack_t))
+
+%splice [ps_message_t] (gen_parser (`message_t))
+
+/// With the above parsers, we can make our `message` type an instance of
+/// Comparse's `parseable_serializeable` class.
+/// Again, the details are not important here,
+/// but this is the step that enables us to call
+/// `parse message buff` and `serialize message msg`
+/// to translate between bytes and our abstract message type.
+
+instance parseable_serializeable_bytes_message_t: parseable_serializeable bytes message_t = mk_parseable_serializeable ps_message_t
+
+
+(*** State Type ***)
+
+/// As for the messages we define abstract state types
+/// for the three states stored by Alice and Bob after each step of the protocol.
+
+[@@ with_bytes bytes]
+type sent_ping_t = {
+  bob : principal;
+  n_a : bytes;
+}
+
+[@@ with_bytes bytes]
+type sent_ack_t = {
+  alice: principal;
+  n_a : bytes;
+}
+
+[@@ with_bytes bytes]
+type received_ack_t = {
+  bob : principal;
+  n_a : bytes;
+}
+
+[@@ with_bytes bytes]
+type state_t = 
+  | SentPing: (ping:sent_ping_t) -> state_t
+  | SentAck: (ack:sent_ack_t) -> state_t
+  | ReceivedAck: (rack:received_ack_t) -> state_t
+
+/// As for messages, we use Comparse to generate
+/// a parser and serializer for our abstract state types.
+
+%splice [ps_sent_ping_t] (gen_parser (`sent_ping_t))
+%splice [ps_sent_ack_t] (gen_parser (`sent_ack_t))
+%splice [ps_received_ack_t] (gen_parser (`received_ack_t))
+%splice [ps_state_t] (gen_parser (`state_t))
+
+/// Now, we can call
+/// `parse state buff` and `serialize state st`
+/// to translate between bytes and the abstract state type.
+
+instance parseable_serializeable_bytes_state_t: parseable_serializeable bytes state_t = mk_parseable_serializeable ps_state_t
+
+/// We tag our protocol level states,
+/// so that they are distinguishable from any internal DY* states. 
+
+instance local_state_state: local_state state_t = {
+  tag = "P.State";
+  format = parseable_serializeable_bytes_state_t;
+}
+
+
+
+(*** PKI ***)
+
+/// For en-/de-cryption we assume some PKI.
+/// I.e., every participant has some private decryption keys
+/// and some public encryption keys from other participants.
+/// All private keys of a participant will be stored in one session
+/// and all public keys that the participant knows will be stored in another session.
+/// For each participant, we collect both these session IDs in a global record.
+
+type global_sess_ids = {
+  pki: state_id;
+  private_keys: state_id;
+}
+
+/// Similarly as for states,
+/// we tag the keys that are used on the protocol level,
+/// so that they can not be confused with other keys.
+/// (TODO: rephrase this)
+
+let key_tag = "P.Key"

--- a/examples/Online_with_secrecy/DY.OnlineS.Protocol.fst
+++ b/examples/Online_with_secrecy/DY.OnlineS.Protocol.fst
@@ -7,136 +7,26 @@ open DY.Lib
 open DY.Simplified
 open DY.Extend
 
-/// The "Online?" protocol
-/// 
-/// An extension of the simple Two Message protocol:
+open DY.OnlineS.Data
+
+/// Here we define the DY* mode of the "Online?" protocol,
+/// an extension of the simple Two Message protocol:
 /// the two messages are now (asymmetrically) encrypted
 ///
 /// A -> B: enc{Ping (A, n_A)}_B
 /// B -> A: enc{Ack n_A}_A
-
-(*** Message Type ***)
-
-/// for each of the two messages we define an abstract message type
-
-[@@ with_bytes bytes] // ignore this line for now
-type ping_t = {
-  p_alice: principal;
-  p_n_a : bytes;
-}
-
-[@@ with_bytes bytes] // ignore this line for now
-type ack = {
-  a_n_a : bytes;
-}
-
-/// the overall abstract message type
-/// (consisting of constructors for the two messages
-/// and using the above abstract types for each of them)
-
-[@@ with_bytes bytes] // ignore this line for now
-type message =
-  | Ping: (ping:ping_t) -> message
-  | Ack: (ack:ack) -> message
-
-
-/// We use Comparse to generate the corresponding message formats.
-/// I.e., we don't need to write parsing and serializing by hand
 ///
-/// for this we need the `[@@ with_bytes bytes]` annotation for the message types above
+/// The model consists of 3 functions,
+/// one for each protocol step
+/// (just as for the simple two message protocol):
+/// 1. Alice sends the Ping to Bob (`send_ping`)
+/// 2. Bob receives the Ping and replies with the Ack (`receive_ping_and_send_ack`)
+/// 3. Alice receives the Ack (`receive_ack`)
 ///
-/// We are not going into the details of how Comparse works.
+/// Additionally, there are two helper functions
+/// for steps 2 and 3 (`decode_ping` and `decode_ack`).
 
-
-/// We let Comparse generate a parser `ps_ping` for the abstract `ping` type
-%splice [ps_ping_t] (gen_parser (`ping_t))
-
-%splice [ps_ack] (gen_parser (`ack))
-
-%splice [ps_message] (gen_parser (`message))
-
-/// With the above parsers, we can make our `message` type an instance of
-/// Comparse's `parseable_serializeable` class.
-/// Again, the details are not important here,
-/// but this is the step that enables us to call
-/// `parse message buff` and `serialize message msg`
-/// to translate between bytes and our abstract message type.
-instance parseable_serializeable_bytes_message: parseable_serializeable bytes message = mk_parseable_serializeable ps_message
-
-
-(*** State Type ***)
-
-/// As for the messages we define abstract state types
-/// for the three states stored by Alice and Bob after each step of the protocol.
-
-[@@ with_bytes bytes]
-type sent_ping = {
-  sp_bob : principal;
-  sp_n_a : bytes;
-}
-
-[@@ with_bytes bytes]
-type sent_ack = {
-  sa_alice: principal;
-  sa_n_a : bytes;
-}
-
-[@@ with_bytes bytes]
-type received_ack = {
-  ra_bob : principal;
-  ra_n_a : bytes;
-}
-
-[@@ with_bytes bytes]
-type state = 
-  | SentPing: (ping:sent_ping) -> state
-  | SentAck: (ack:sent_ack) -> state
-  | ReceivedAck: (rack:received_ack) -> state
-
-/// As for messages, we use Comparse to generate
-/// a parser and serializer for our abstract state type.
-
-%splice [ps_sent_ping] (gen_parser (`sent_ping))
-%splice [ps_sent_ack] (gen_parser (`sent_ack))
-%splice [ps_received_ack] (gen_parser (`received_ack))
-%splice [ps_state] (gen_parser (`state))
-
-/// Now, we can call
-/// `parse state buff` and `serialize state st`
-/// to translate between bytes and the abstract state type.
-instance parseable_serializeable_bytes_state: parseable_serializeable bytes state = mk_parseable_serializeable ps_state
-
-/// We tag our protocol level states,
-/// so that they are distinguishable from any internal DY* states. 
-
-instance local_state_state: local_state state = {
-  tag = "P.State";
-  format = parseable_serializeable_bytes_state;
-}
-
-(*** PKI ***)
-
-/// For en-/de-cryption we assume some PKI.
-/// I.e., every participant has some private decryption keys
-/// and some public encryption keys from other participants.
-/// All private keys of a participant will be stored in one session
-/// and all public keys that the participant knows will be stored in another session.
-/// For each participant, we collect both these session IDs in a global record.
-
-type global_sess_ids = {
-  pki: state_id;
-  private_keys: state_id;
-}
-
-/// Similarly as for states,
-/// we tag the keys that are used on the protocol level,
-/// so that they can not be confused with other keys.
-
-let key_tag = "P.Key"
-
-(*** The Protocol ***)
-
-let nonce_label alice bob = join (principal_label alice) (principal_label bob)
+(*** Sending the Ping ***)
 
 /// Alice sends the first message to Bob:
 /// * Alice generates a new nonce [n_a]
@@ -145,25 +35,30 @@ let nonce_label alice bob = join (principal_label alice) (principal_label bob)
 /// * stores n_a and Bob in a state (in a new session)
 /// The step returns the ID of the new state
 /// and the timestamp of the message on the trace
-/// The step fails (returns None), if
+/// The step fails, if
 /// encryption was not successful, i.e.,
 /// Alice does not have a public key of Bob.
+
+let nonce_label alice bob = join (principal_label alice) (principal_label bob)
 
 val send_ping: principal -> principal -> state_id -> traceful (option (state_id & timestamp))
 let send_ping alice bob keys_sid =
   // TODO: explain high-level idea of "intended readers"
-  let* n_a = gen_rand_labeled (nonce_label alice bob) in
+  let* n_a = gen_rand_labeled (join (principal_label alice) (principal_label bob)) in
   
-  let ping = Ping {p_alice = alice; p_n_a = n_a} in 
+  let ping = Ping {alice; n_a} in 
 
   // encrypt the message for bob
   let*? ping_encrypted = pk_enc_for alice bob keys_sid key_tag ping in
   let* msg_ts = send_msg ping_encrypted in
 
-  let ping_state = SentPing {sp_bob = bob; sp_n_a = n_a} in
+  let ping_state = SentPing {bob; n_a} in
   let* sid = start_new_session alice ping_state in
 
   return (Some (sid, msg_ts))
+
+
+(*** Replying to a Ping with an Ack ***)
 
 
 /// Bob receives the first messages and replies:
@@ -179,7 +74,7 @@ let send_ping alice bob keys_sid =
 /// * the message is not of the right type, i.e., not a first message
 /// * encryption fails
 
-/// Decrypting the message (Step 2 from above) is pulled out to a separate function.
+/// Decrypting the message (Step 2 from above) is pulled out to a separate function
 /// The function
 /// * decrypts the message
 /// * checks that the message is of the right type (a Ping)
@@ -189,9 +84,9 @@ let send_ping alice bob keys_sid =
 val decode_ping : principal -> state_id -> bytes -> traceful (option ping_t)
 let decode_ping bob keys_sid msg =
   // try to decrypt the message with
-  // a private key of bob with the protocol key tag
+  // a private key of bob with the protocol tag
   // (fails, if no such key exists)
-  let*? png = pk_dec_with_key_lookup #message bob keys_sid key_tag msg in
+  let*? png = pk_dec_with_key_lookup #message_t bob keys_sid key_tag msg in
   
   // check that the decrypted message is of the right type
   // (otherwise fail)
@@ -209,17 +104,20 @@ let receive_ping_and_send_ack bob global_sids msg_ts =
   // decode the received expected ping
   let*? png = decode_ping bob global_sids.private_keys msg in
 
-  let n_a = png.p_n_a in
-  let alice = png.p_alice in
+  let n_a = png.n_a in
+  let alice = png.alice in
 
-  let ack = Ack {a_n_a = n_a} in
+  let ack = Ack {n_a} in
   // encrypt the reply for alice
   let*? ack_encrypted = pk_enc_for bob alice global_sids.pki key_tag ack in
   let* ack_ts = send_msg ack_encrypted in
   
-  let* sess_id = start_new_session bob (SentAck {sa_alice = alice; sa_n_a = n_a}) in
+  let* sess_id = start_new_session bob (SentAck {alice; n_a}) in
   
   return (Some (sess_id, ack_ts))
+
+
+(*** Receiving an Ack ***)
 
 
 /// Alice receives the reply from Bob:
@@ -240,11 +138,11 @@ let receive_ping_and_send_ack bob global_sids msg_ts =
 /// Returns the content of the reply.
 /// Fails if decryption fails.
 
-val decode_ack : principal -> state_id -> bytes -> traceful (option ack)
+val decode_ack : principal -> state_id -> bytes -> traceful (option ack_t)
 let decode_ack alice keys_sid cipher =
   // try to decrypt the message with
   // a private key of alice with the protocol tag
-  let*? ack = pk_dec_with_key_lookup #message alice keys_sid key_tag cipher in
+  let*? ack = pk_dec_with_key_lookup #message_t alice keys_sid key_tag cipher in
 
   // check that the decrypted message is of the Ack type
   guard_tr (Ack? ack);*?
@@ -259,13 +157,14 @@ let receive_ack alice keys_sid ack_ts =
   // decode the received expected ack
   let*? ack = decode_ack alice keys_sid msg in
 
-  let n_a = ack.a_n_a in
-  let*? (st, sid) = lookup_state #state alice
-    (fun st -> SentPing? st && (SentPing?.ping st).sp_n_a = n_a)
+  let n_a = ack.n_a in
+
+  let*? (st, sid) = lookup_state #state_t alice
+    (fun st -> SentPing? st && (SentPing?.ping st).n_a = n_a)
     in
   guard_tr(SentPing? st);*?
-  let bob = (SentPing?.ping st).sp_bob in
+  let bob = (SentPing?.ping st).bob in
 
-  set_state alice sid (ReceivedAck {ra_bob=bob; ra_n_a = n_a});*
+  set_state alice sid (ReceivedAck {bob; n_a});*
 
   return (Some sid)

--- a/examples/Online_with_secrecy/DY.OnlineS.Run.Printing.fst
+++ b/examples/Online_with_secrecy/DY.OnlineS.Run.Printing.fst
@@ -3,7 +3,8 @@ module DY.OnlineS.Run.Printing
 open DY.Core
 open DY.Lib
 open Comparse
-open DY.OnlineS.Protocol
+
+open DY.OnlineS.Data
 
 /// Helper functions for trace printing.
 /// Here we define how our abstract message and state types
@@ -12,17 +13,17 @@ open DY.OnlineS.Protocol
 
 val message_to_string: bytes -> option string
 let message_to_string b =
-  match? parse message b with
-  | Ping p -> Some (Printf.sprintf "Ping [name = (%s), n_a = (%s)]" (p.p_alice) (bytes_to_string p.p_n_a))
-  | Ack a -> Some (Printf.sprintf "Ping [n_a = (%s)]" (bytes_to_string a.a_n_a))
+  match? parse message_t b with
+  | Ping p -> Some (Printf.sprintf "Ping [name = (%s), n_a = (%s)]" (p.alice) (bytes_to_string p.n_a))
+  | Ack a -> Some (Printf.sprintf "Ping [n_a = (%s)]" (bytes_to_string a.n_a))
 
 
 val state_to_string: bytes -> option string
 let state_to_string b =
-  match? parse state b with
-  | SentPing p -> Some (Printf.sprintf "SentPing [to = (%s), n_a = (%s)]" p.sp_bob (bytes_to_string p.sp_n_a))
-  | SentAck a -> Some (Printf.sprintf "SentAck [to = (%s), n_a = (%s)]" a.sa_alice (bytes_to_string a.sa_n_a))
-  | ReceivedAck r -> Some (Printf.sprintf "ReceivedAck [from = (%s), n_a = (%s)]" r.ra_bob (bytes_to_string r.ra_n_a))
+  match? parse state_t b with
+  | SentPing p -> Some (Printf.sprintf "SentPing [to = (%s), n_a = (%s)]" p.bob (bytes_to_string p.n_a))
+  | SentAck a -> Some (Printf.sprintf "SentAck [to = (%s), n_a = (%s)]" a.alice (bytes_to_string a.n_a))
+  | ReceivedAck r -> Some (Printf.sprintf "ReceivedAck [from = (%s), n_a = (%s)]" r.bob (bytes_to_string r.n_a))
 
 
 

--- a/examples/Online_with_secrecy/DY.OnlineS.Run.fst
+++ b/examples/Online_with_secrecy/DY.OnlineS.Run.fst
@@ -4,6 +4,7 @@ open DY.Core
 open DY.Lib
 
 open DY.OnlineS.Run.Printing
+open DY.OnlineS.Data
 open DY.OnlineS.Protocol
 
 /// Here, we print the trace after a successful run of the Two Message protocol.

--- a/examples/Online_with_secrecy/DY.OnlineS.Secrecy.fst
+++ b/examples/Online_with_secrecy/DY.OnlineS.Secrecy.fst
@@ -4,7 +4,7 @@ open Comparse
 open DY.Core
 open DY.Lib
 
-open DY.OnlineS.Protocol
+open DY.OnlineS.Data
 open DY.OnlineS.Invariants
 
 
@@ -30,8 +30,8 @@ val n_a_secrecy:
   (requires
     attacker_knows tr n_a /\
     trace_invariant tr /\ (
-      (exists sess_id. state_was_set tr alice sess_id (SentPing {sp_bob = bob; sp_n_a = n_a})) \/
-      (exists sess_id. state_was_set tr bob sess_id (ReceivedAck {ra_bob = bob; ra_n_a = n_a} ))
+      (exists sess_id. state_was_set tr alice sess_id (SentPing {bob; n_a})) \/
+      (exists sess_id. state_was_set tr bob sess_id (ReceivedAck {bob; n_a} ))
     )
   )
   (ensures is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob))

--- a/examples/TwoMessageP/DY.TwoMessage.Data.fst
+++ b/examples/TwoMessageP/DY.TwoMessage.Data.fst
@@ -1,0 +1,115 @@
+module DY.TwoMessage.Data
+
+open Comparse
+open DY.Core
+open DY.Lib
+
+/// Here we define the abstract types for the simple 2 message protocol:
+/// 
+/// A -> B: Ping (A, n_A)
+/// B -> A: Ack n_A
+
+
+(*** Message Type ***)
+
+/// for each of the two messages we define an abstract message type
+
+[@@ with_bytes bytes] // ignore this line for now
+type ping_t = {
+  alice: principal;
+  n_a : bytes;
+}
+
+[@@ with_bytes bytes] // ignore this line for now
+type ack_t = {
+  n_a : bytes;
+}
+
+/// the overall abstract message type
+/// (consisting of constructors for the two messages
+/// and using the above abstract types for each of them)
+
+[@@ with_bytes bytes] // ignore this line for now
+type message_t =
+  | Ping: ping_t -> message_t
+  | Ack: ack_t -> message_t
+
+
+/// We use Comparse to generate the corresponding message formats.
+/// I.e., we don't need to write parsing and serializing by hand
+///
+/// for this we need the `[@@ with_bytes bytes]` annotation for the message types above
+///
+/// We are not going into the details of how Comparse works.
+
+
+/// We let Comparse generate a parser `ps_ping_t` for the abstract `ping_t` type
+
+%splice [ps_ping_t] (gen_parser (`ping_t))
+
+/// ... and the same for the other abstract message types
+
+%splice [ps_ack_t] (gen_parser (`ack_t))
+
+%splice [ps_message_t] (gen_parser (`message_t))
+
+/// With the above parsers, we can make our `message` type an instance of
+/// Comparse's `parseable_serializeable` class.
+/// Again, the details are not important here,
+/// but this is the step that enables us to call
+/// `parse message buff` and `serialize message msg`
+/// to translate between bytes and our abstract message type.
+
+instance parseable_serializeable_bytes_message_t: parseable_serializeable bytes message_t = mk_parseable_serializeable ps_message_t
+
+
+(*** State Type ***)
+
+/// As for the messages we define abstract state types
+/// for the three states stored by Alice and Bob after each step of the protocol.
+
+[@@ with_bytes bytes]
+type sent_ping_t = {
+  bob : principal;
+  n_a : bytes;
+}
+
+[@@ with_bytes bytes]
+type sent_ack_t = {
+  alice: principal;
+  n_a : bytes;
+}
+
+[@@ with_bytes bytes]
+type received_ack_t = {
+  bob : principal;
+  n_a : bytes;
+}
+
+[@@ with_bytes bytes]
+type state_t = 
+  | SentPing: (ping:sent_ping_t) -> state_t
+  | SentAck: (ack:sent_ack_t) -> state_t
+  | ReceivedAck: (rack:received_ack_t) -> state_t
+
+/// As for messages, we use Comparse to generate
+/// a parser and serializer for our abstract state types.
+
+%splice [ps_sent_ping_t] (gen_parser (`sent_ping_t))
+%splice [ps_sent_ack_t] (gen_parser (`sent_ack_t))
+%splice [ps_received_ack_t] (gen_parser (`received_ack_t))
+%splice [ps_state_t] (gen_parser (`state_t))
+
+/// Now, we can call
+/// `parse state buff` and `serialize state st`
+/// to translate between bytes and the abstract state type.
+
+instance parseable_serializeable_bytes_state_t: parseable_serializeable bytes state_t = mk_parseable_serializeable ps_state_t
+
+/// We tag our protocol level states,
+/// so that they are distinguishable from any internal DY* states. 
+
+instance local_state_state: local_state state_t = {
+  tag = "P.State";
+  format = parseable_serializeable_bytes_state_t;
+}

--- a/examples/TwoMessageP/DY.TwoMessage.Protocol.fst
+++ b/examples/TwoMessageP/DY.TwoMessage.Protocol.fst
@@ -7,116 +7,22 @@ open DY.Lib
 open DY.Simplified
 open DY.Extend
 
-/// A simple 2 message protocol
+open DY.TwoMessage.Data
+
+/// Here we define the DY* model of the
+/// simple 2 message protocol:
 ///
 /// A -> B: Ping (A, n_A)
 /// B -> A: Ack n_A
-
-(*** Message Type ***)
-
-/// for each of the two messages we define an abstract message type
-
-[@@ with_bytes bytes] // ignore this line for now
-type ping_t = {
-  alice: principal;
-  n_a : bytes;
-}
-
-[@@ with_bytes bytes] // ignore this line for now
-type ack_t = {
-  n_a : bytes;
-}
-
-/// the overall abstract message type
-/// (consisting of constructors for the two messages
-/// and using the above abstract types for each of them)
-
-[@@ with_bytes bytes] // ignore this line for now
-type message_t =
-  | Ping: ping_t -> message_t
-  | Ack: ack_t -> message_t
-
-
-/// We use Comparse to generate the corresponding message formats.
-/// I.e., we don't need to write parsing and serializing by hand
 ///
-/// for this we need the `[@@ with_bytes bytes]` annotation for the message types above
-///
-/// We are not going into the details of how Comparse works.
+/// The model consists of 3 functions,
+/// one for each action:
+/// 1. Alice sends the Ping to Bob (`send_ping`)
+/// 2. Bob receives the Ping and replies with the Ack (`receive_ping_and_send_ack`)
+/// 3. Alice receives the Ack (`receive_ack`)
 
 
-/// We let Comparse generate a parser `ps_ping_t` for the abstract `ping_t` type
-
-%splice [ps_ping_t] (gen_parser (`ping_t))
-
-/// ... and the same for the other abstract message types
-
-%splice [ps_ack_t] (gen_parser (`ack_t))
-
-%splice [ps_message_t] (gen_parser (`message_t))
-
-/// With the above parsers, we can make our `message` type an instance of
-/// Comparse's `parseable_serializeable` class.
-/// Again, the details are not important here,
-/// but this is the step that enables us to call
-/// `parse message buff` and `serialize message msg`
-/// to translate between bytes and our abstract message type.
-
-instance parseable_serializeable_bytes_message_t: parseable_serializeable bytes message_t = mk_parseable_serializeable ps_message_t
-
-
-(*** State Type ***)
-
-/// As for the messages we define abstract state types
-/// for the three states stored by Alice and Bob after each step of the protocol.
-
-[@@ with_bytes bytes]
-type sent_ping_t = {
-  bob : principal;
-  n_a : bytes;
-}
-
-[@@ with_bytes bytes]
-type sent_ack_t = {
-  alice: principal;
-  n_a : bytes;
-}
-
-[@@ with_bytes bytes]
-type received_ack_t = {
-  bob : principal;
-  n_a : bytes;
-}
-
-[@@ with_bytes bytes]
-type state_t = 
-  | SentPing: (ping:sent_ping_t) -> state_t
-  | SentAck: (ack:sent_ack_t) -> state_t
-  | ReceivedAck: (rack:received_ack_t) -> state_t
-
-/// As for messages, we use Comparse to generate
-/// a parser and serializer for our abstract state types.
-
-%splice [ps_sent_ping_t] (gen_parser (`sent_ping_t))
-%splice [ps_sent_ack_t] (gen_parser (`sent_ack_t))
-%splice [ps_received_ack_t] (gen_parser (`received_ack_t))
-%splice [ps_state_t] (gen_parser (`state_t))
-
-/// Now, we can call
-/// `parse state buff` and `serialize state st`
-/// to translate between bytes and the abstract state type.
-
-instance parseable_serializeable_bytes_state_t: parseable_serializeable bytes state_t = mk_parseable_serializeable ps_state_t
-
-/// We tag our protocol level states,
-/// so that they are distinguishable from any internal DY* states. 
-
-instance local_state_state: local_state state_t = {
-  tag = "P.State";
-  format = parseable_serializeable_bytes_state_t;
-}
-
-(*** The Protocol ***)
+(*** Sending the Ping ***)
 
 /// Alice sends the first message to Bob:
 /// * Alice generates a new nonce [n_a]
@@ -143,6 +49,8 @@ let send_ping alice bob =
   // return the ID of the new session and the timestamp of the message
   return (sid, msg_ts)
 
+
+(*** Replying to a Ping with an Ack ***)
 
 /// Bob receives the first messages and replies:
 /// * read the message (Alice, n_a) from the trace
@@ -181,6 +89,8 @@ let receive_ping_and_send_ack bob msg_ts =
   // return the ID of the new session and the timestamp of the message
   return (Some (sess_id, ack_ts))
 
+
+(*** Receiving an Ack ***)
 
 /// Alice receives the reply from Bob:
 /// * read the message (n_a) from the trace

--- a/examples/TwoMessageP/DY.TwoMessage.Run.Printing.fst
+++ b/examples/TwoMessageP/DY.TwoMessage.Run.Printing.fst
@@ -3,7 +3,7 @@ module DY.TwoMessage.Run.Printing
 open DY.Core
 open DY.Lib
 open Comparse
-open DY.TwoMessage.Protocol
+open DY.TwoMessage.Data
 
 /// Helper functions for trace printing.
 /// Here we define how our abstract message and state types


### PR DESCRIPTION
I moved the definitions of the abstract message and state types to a separate file.
Together with their parser generation.
Since the parser generation takes some time, it is faster to move them out of the Protocol model when re-checking the model.