### PR TITLE
Removed unnecessary state invariant in Online Protocol

### DIFF
--- a/dy-extensions/DY.Extend.fst
+++ b/dy-extensions/DY.Extend.fst
@@ -5,22 +5,50 @@ open DY.Core
 open DY.Lib
 open DY.Core.Trace.Base
 
+let core_state_was_set_grows  tr1 tr2 prin sid cont:
+  Lemma 
+  (requires
+    tr1 <$ tr2
+    /\ state_was_set tr1 prin sid cont
+  )
+  (ensures
+    state_was_set tr2 prin sid cont
+  )
+  [SMTPat (state_was_set tr1 prin sid cont); SMTPat (tr1 <$ tr2)]
+  = ()
+
+
+let state_was_set_grows (#a:Type) {|ls:local_state a|} tr1 tr2 prin sid (cont : a):
+  Lemma 
+  (requires
+    tr1 <$ tr2
+    /\ DY.Lib.state_was_set tr1 prin sid cont
+  )
+  (ensures
+    DY.Lib.state_was_set tr2 prin sid cont
+  )
+  [SMTPat (DY.Lib.state_was_set tr1 prin sid cont); SMTPat (tr1 <$ tr2)]
+  = 
+  reveal_opaque (`%DY.Lib.state_was_set) (DY.Lib.state_was_set #a);
+  reveal_opaque (`%tagged_state_was_set) (tagged_state_was_set)
+
+
 let state_was_set_some_id (#a:Type) {|local_state a|} tr prin (cont : a) =
   exists sid. DY.Lib.state_was_set tr prin sid cont
 
-val state_was_set_some_id_grows:
-  #a:Type -> {|lsa:local_state a|} ->
-  tr1:trace -> tr2:trace -> 
-  prin:principal -> content:a ->
-  Lemma
-  (requires tr1 <$ tr2
-    /\ state_was_set_some_id tr1 prin content
-  )
-  (ensures
-    state_was_set_some_id tr2 prin content
-  )
-  [SMTPat (state_was_set_some_id #a #lsa tr1 prin content); SMTPat (tr1 <$ tr2)]
-let state_was_set_some_id_grows #a #ls tr1 tr2 prin content  = admit()
+// val state_was_set_some_id_grows:
+//   #a:Type -> {|lsa:local_state a|} ->
+//   tr1:trace -> tr2:trace -> 
+//   prin:principal -> content:a ->
+//   Lemma
+//   (requires tr1 <$ tr2
+//     /\ state_was_set_some_id tr1 prin content
+//   )
+//   (ensures
+//     state_was_set_some_id tr2 prin content
+//   )
+//   [SMTPat (state_was_set_some_id #a #lsa tr1 prin content); SMTPat (tr1 <$ tr2)]
+// let state_was_set_some_id_grows #a #ls tr1 tr2 prin content  = ()
 
 
 /// Lookup the most recent state of a principal satisfying some property.

--- a/dy-extensions/DY.Simplified.fst
+++ b/dy-extensions/DY.Simplified.fst
@@ -64,7 +64,6 @@ val pk_enc_for_is_publishable:
       trace_invariant tr
     /\ has_pki_invariant
     /\ bytes_invariant tr msg_b
-    // /\ is_knowable_by ( principal_label alice `join` principal_label bob ) tr (serialize a msg)
     /\ (get_label tr msg_b) `can_flow tr` (long_term_key_label bob)
     /\ (get_label tr msg_b) `can_flow tr` (long_term_key_label alice)
     /\ (pkenc_pred.pred tr (long_term_key_type_to_usage (LongTermPkEncKey key_tag) bob) msg_b

--- a/examples/Online_with_secrecy/DY.OnlineS.Invariants.Proofs.fst
+++ b/examples/Online_with_secrecy/DY.OnlineS.Invariants.Proofs.fst
@@ -349,8 +349,12 @@ let receive_ping_and_send_ack_invariant bob bob_keys_sid msg_ts tr =
                   assert(is_knowable_by (nonce_label alice bob) tr n_a);
                   serialize_wf_lemma message_t (is_knowable_by (nonce_label alice bob) tr) ack;
 
-                  (* The final requirement,
-                     follows from our helper lemma `decode_ping_proof`*)
+                  (* The final requirement is trivially satisfied, 
+                     since the pkenc_pred for an Ack is just True
+
+                     You can check:
+                     assert(pkenc_pred.pred tr (long_term_key_type_to_usage (LongTermPkEncKey key_tag) alice) (serialize message_t ack));
+                  *)
                 (* Thus, we can call `pk_enc_for_is_publishable`
                    to get the missing pre-condition for `send_msg_invariant`.*)
                 pk_enc_for_is_publishable tr bob alice bob_keys_sid.pki key_tag ack;
@@ -363,9 +367,7 @@ let receive_ping_and_send_ack_invariant bob bob_keys_sid msg_ts tr =
                    For the new SentAck state, this means that
                    the stored nonce
                    must be readble by
-                   * the storing principal (here bob)
-                   * the principal stored in the first component of the state 
-                     (here: alice received in the Ping message)
+                   the storing principal (here bob).
 
                    We get this property from our helper lemma `decode_ping_proof`.
                 *)

--- a/examples/Online_with_secrecy/DY.OnlineS.Secrecy.fst
+++ b/examples/Online_with_secrecy/DY.OnlineS.Secrecy.fst
@@ -31,9 +31,20 @@ val n_a_secrecy:
     attacker_knows tr n_a /\
     trace_invariant tr /\ (
       (exists sess_id. state_was_set tr alice sess_id (SentPing {bob; n_a})) \/
-      (exists sess_id. state_was_set tr bob sess_id (ReceivedAck {bob; n_a} ))
+      (exists sess_id. state_was_set tr alice sess_id (ReceivedAck {bob; n_a} ))
     )
   )
   (ensures is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob))
+
+/// The proof idea is the following:
+/// For any nonce stored in one of Alice's states (SentPing or ReceivedAck)
+/// together with Bob,
+/// we get from the state predicate in the protocol invariants,
+/// that the nonce is labeled for exactly Alice and Bob.
+///
+/// This immediately means that one of Alice or Bob must be corrupted,
+/// if the attacker knows the nonce.
+/// The proof thus only consists of calling the main attacker lemma
+/// `attacker_only_knows_publishable_values`.
 let n_a_secrecy tr alice bob n_a =
   attacker_only_knows_publishable_values tr n_a


### PR DESCRIPTION
Since we can only show the secrecy of the nonce stored at Alice,
I removed invariants that are not needed for the proof.