### PR TITLE
feat: add workflow to update `flake.lock`

### DIFF
--- a/.github/workflows/update_flake_lock.yml
+++ b/.github/workflows/update_flake_lock.yml
@@ -1,0 +1,20 @@
+name: Update flake.lock
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: [ self-hosted, nix ]
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+
+    - name: update flake.lock
+      run: nix flake update
+
+    - name: upload flake.lock
+      uses: actions/upload-artifact@v4
+      with:
+        name: flake.lock
+        path: flake.lock

--- a/flake.lock
+++ b/flake.lock
@@ -36,16 +36,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1730802798,
-        "narHash": "sha256-C+og4+WhgzH56UAtEGjG2ZTiPvwXw+VSYTJ9uJlZEjI=",
+        "lastModified": 1729689309,
+        "narHash": "sha256-J/gD3m0UUsqdy0ZT6s8W/aIvt1UDVpqf+rLaHZTttWk=",
         "owner": "REPROSEC",
         "repo": "dolev-yao-star-extrinsic",
-        "rev": "233597da0fb38f13f24e5cd25e7a015fb6278312",
+        "rev": "e8db01fcbd8be73cbae27828dc304a1fbe01530b",
         "type": "github"
       },
       "original": {
         "owner": "REPROSEC",
-        "ref": "twal/build",
         "repo": "dolev-yao-star-extrinsic",
         "type": "github"
       }
@@ -73,11 +72,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1729816826,
-        "narHash": "sha256-7+0Z5klNHUzDTew1ivQ6YqxHKUR+fLLUWfac82X9SBM=",
+        "lastModified": 1727737011,
+        "narHash": "sha256-B875NYwASSMUvVEieG7aXm1xQ/z7I9rCSSwaJlzT1A4=",
         "owner": "FStarLang",
         "repo": "FStar",
-        "rev": "8b6fce63ca91b16386d8f76e82ea87a3c109a208",
+        "rev": "061fcdf98085ac5e195773a3f20764637cc7cab3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     nixpkgs.follows = "dolev-yao-star-flake/nixpkgs";
     fstar-flake.follows = "dolev-yao-star-flake/fstar-flake";
     comparse-flake.follows = "dolev-yao-star-flake/comparse-flake";
-    dolev-yao-star-flake.url = "github:REPROSEC/dolev-yao-star-extrinsic?ref=twal/build";
+    dolev-yao-star-flake.url = "github:REPROSEC/dolev-yao-star-extrinsic";
   };
 
   outputs = {self, nixpkgs, fstar-flake, comparse-flake, dolev-yao-star-flake}:


### PR DESCRIPTION
If people want to update the flake.lock file but don't want to install nix, this PR adds a github action that creates an updated flake.lock.

Once this is merged, there will be a button "run workflow" on the left at [this page](https://github.com/REPROSEC/dolev-yao-star-tutorial-code/actions/workflows/update_flake_lock.yml)
(to access it, click "Actions", next "Update flake.lock" on the left bar)
This produces an updated flake.lock, available in the action summary (e.g. [here](https://github.com/REPROSEC/dolev-yao-star-tutorial-code/actions/runs/11978833362))

This also cleans up some mess I have left in the flake.nix in #4 (oops)