### PR TITLE
Propagate core dys changes

### DIFF
--- a/dy-extensions/DY.Extend.fst
+++ b/dy-extensions/DY.Extend.fst
@@ -5,6 +5,22 @@ open DY.Core
 open DY.Lib
 open DY.Core.Trace.Base
 
+val is_secret_is_knowable: 
+  {|cinvs: crypto_invariants|} ->
+  l:label  -> 
+  tr: trace ->
+  b:bytes ->
+  Lemma 
+  (requires is_secret l tr b)
+  (ensures is_knowable_by l tr b)
+  [SMTPat (is_secret #cinvs l tr b)]
+let is_secret_is_knowable l tr b = ()
+
+let rand_generated_before tr b = 
+  is_not_empty tr /\
+  exists ts. rand_generated_at tr ts b
+
+
 let core_state_was_set_grows  tr1 tr2 prin sid cont:
   Lemma 
   (requires

--- a/examples/Online/DY.Online.Run.fst
+++ b/examples/Online/DY.Online.Run.fst
@@ -80,4 +80,4 @@ let run () : traceful (option unit ) =
 
   return (Some ())
 
-let _ = run () Nil
+let _ = run () empty_trace

--- a/examples/Online_with_secrecy/DY.OnlineS.Invariants.fst
+++ b/examples/Online_with_secrecy/DY.OnlineS.Invariants.fst
@@ -104,7 +104,7 @@ instance crypto_invariants_p: crypto_invariants = {
 %splice [ps_received_ack_t_is_well_formed] (gen_is_well_formed_lemma (`received_ack_t))
 %splice [ps_state_t_is_well_formed] (gen_is_well_formed_lemma (`state_t))
 
-#push-options "--z3cliopt 'smt.qi.eager_threshold=50'"
+#push-options "--ifuel 2 --z3cliopt 'smt.qi.eager_threshold=50'"
 (* We restrict what states are allowed to be stored by principals *)
 let state_predicate_p: local_state_predicate state_t = {
   pred = (fun tr prin sess_id st ->
@@ -155,12 +155,7 @@ let state_predicate_p: local_state_predicate state_t = {
      the content of the state to be stored
      is readable by the storing principal
   *)
-  pred_knowable = (fun tr prin sess_id st -> 
-    match st with
-    | SentAck ack ->
-        parse_wf_lemma state_t (is_knowable_by (principal_label prin) tr) ack.n_a
-    | _ -> ()
-  );
+  pred_knowable = (fun tr prin sess_id st -> () );
 }
 #pop-options
 

--- a/examples/Online_with_secrecy/DY.OnlineS.Run.fst
+++ b/examples/Online_with_secrecy/DY.OnlineS.Run.fst
@@ -80,4 +80,4 @@ let run () : traceful (option unit ) =
 
   return (Some ())
 
-let _ = run () Nil
+let _ = run () empty_trace

--- a/examples/TwoMessageP/DY.TwoMessage.Run.fst
+++ b/examples/TwoMessageP/DY.TwoMessage.Run.fst
@@ -43,4 +43,4 @@ let run () : traceful (option unit ) =
 
 /// Call `run` when the module loads
 
-let _ = run () Nil
+let _ = run () empty_trace

--- a/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.Debug.fst
+++ b/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.Debug.fst
@@ -75,5 +75,5 @@ let debug () : traceful (option unit)  =
 
 //Run ``debug ()`` when the module loads
 #push-options "--warn_error -272"
-let _ = debug () Nil
+let _ = debug () empty_trace
 #pop-options

--- a/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -27,7 +27,7 @@ let state_predicate_nsl: local_state_predicate nsl_session = {
       let alice = prin in
       is_knowable_by (nonce_label alice bob) tr n_a /\
       is_secret (nonce_label alice bob) tr n_a /\
-      0 < DY.Core.Trace.Base.length tr /\
+      is_not_empty tr /\
       rand_generated_before tr n_a
     )
     | ResponderSendingMsg2 alice n_a n_b -> (
@@ -37,7 +37,7 @@ let state_predicate_nsl: local_state_predicate nsl_session = {
       
       event_triggered tr bob (Responding alice bob n_a n_b)
       // is_secret (nonce_label alice bob) tr n_b /\
-      //  0 < DY.Core.Trace.Base.length tr /\
+      //  is_not_empty tr /\
       // rand_generated_before tr n_b
     )
     | InitiatorSendingMsg3 bob n_a n_b  -> (
@@ -82,8 +82,7 @@ let event_predicate_nsl: event_predicate nsl_event =
     | Responding alice bob n_a n_b -> (
       prin == bob /\
       is_secret (nonce_label alice bob) tr n_b /\
-      0 < DY.Core.Trace.Base.length tr /\
-      rand_generated_at tr (DY.Core.Trace.Base.length tr - 1) n_b
+      rand_just_generated tr n_b
     )
    
     

--- a/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -27,7 +27,6 @@ let state_predicate_nsl: local_state_predicate nsl_session = {
       let alice = prin in
       is_knowable_by (nonce_label alice bob) tr n_a /\
       is_secret (nonce_label alice bob) tr n_a /\
-      is_not_empty tr /\
       rand_generated_before tr n_a
     )
     | ResponderSendingMsg2 alice n_a n_b -> (
@@ -37,7 +36,6 @@ let state_predicate_nsl: local_state_predicate nsl_session = {
       
       event_triggered tr bob (Responding alice bob n_a n_b)
       // is_secret (nonce_label alice bob) tr n_b /\
-      //  is_not_empty tr /\
       // rand_generated_before tr n_b
     )
     | InitiatorSendingMsg3 bob n_a n_b  -> (

--- a/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.Protocol.Total.Proof.fst
+++ b/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.Protocol.Total.Proof.fst
@@ -81,17 +81,6 @@ instance crypto_invariants_nsl : crypto_invariants = {
 
 (*** Proofs ***)
 
-let is_secret_is_knowable l tr b:
-  Lemma 
-  (requires is_secret l tr b)
-  (ensures is_knowable_by l tr b)
-  [SMTPat (is_secret l tr b)]
-  = ()
-
-let rand_generated_before tr b = 
-  exists ts. rand_generated_at tr ts b
-
-
 val compute_message1_proof:
   tr:trace ->
   alice:principal -> bob:principal -> pk_b:bytes -> n_a:bytes -> nonce:bytes ->

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732272111,
-        "narHash": "sha256-xHDT6wnZDlInnWk19idc7Blp4bLCsfEQwSHAAekiwUE=",
+        "lastModified": 1732872022,
+        "narHash": "sha256-NzxnEUE3HjEe152T+ttCBb+PbHHtMgHZ8GGrYcHkMV8=",
         "owner": "REPROSEC",
         "repo": "dolev-yao-star-extrinsic",
-        "rev": "29a6b9ba65338c034b418d9e13b00c9678adf264",
+        "rev": "f3e40496fb1a3431323974baac3b46f316a78166",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
I propagated the reworked trace API changes from the core DY* repo, i.e., now using `empty_trace` and `rand_just_generated`