### PR TITLE
Added Invariant Lemmas for Decode Message Functions

### DIFF
--- a/dy-extensions/DY.Extend.fst
+++ b/dy-extensions/DY.Extend.fst
@@ -67,6 +67,14 @@ let state_was_set_some_id (#a:Type) {|local_state a|} tr prin (cont : a) =
 // let state_was_set_some_id_grows #a #ls tr1 tr2 prin content  = ()
 
 
+
+val empty_invariants:
+  {| protocol_invariants |} ->
+  Lemma (trace_invariant empty_trace)
+let empty_invariants #pinvs = 
+  normalize_term_spec trace_invariant
+
+
 /// Lookup the most recent state of a principal satisfying some property.
 /// Returns the state and corresponding state id,
 /// or `None` if no such state exists.

--- a/examples/Online_with_secrecy/DY.OnlineS.Invariants.Proofs.fst
+++ b/examples/Online_with_secrecy/DY.OnlineS.Invariants.Proofs.fst
@@ -225,6 +225,17 @@ let send_ping_invariant_short_version alice bob keys_sid  tr =
 
 (*** Replying to a Ping maintains the invariants ***)
 
+val decode_ping_invariant:
+  bob:principal -> keys_sid:state_id ->
+  msg:bytes ->
+  tr:trace ->
+  Lemma
+  (requires trace_invariant tr)
+  (ensures (
+    let (_, tr_out) = decode_ping bob keys_sid msg tr in
+    trace_invariant tr_out
+  ))
+let decode_ping_invariant bob keys_sid msg tr = ()
 
 (* For the second protocol step (`receive_ping_and_send_ack`),
    we need a helper lemma: `decode_ping_proof`.
@@ -381,6 +392,20 @@ let receive_ping_and_send_ack_invariant bob bob_keys_sid msg_ts tr =
 
 
 (*** Receiving an Ack maintains the invariants ***)
+
+val decode_ack_invariant:
+  alice:principal -> keys_sid:state_id -> cipher:bytes ->
+  tr:trace ->
+  Lemma
+  (requires
+    trace_invariant tr
+  )
+  (ensures (
+    let (_, tr_out) = decode_ack alice keys_sid cipher tr in
+    trace_invariant tr_out
+  ))
+let decode_ack_invariant alice keys_sid msg tr = ()
+
 
 /// The invariant lemma for the final protocol step `receive_ack_invariant`
 


### PR DESCRIPTION
Added trace invariant lemmas for the message decode steps in the Online secrecy model. For consistency and didactic reasons.

And a general lemma that the empty trace satisfies the trace invariant. (This should move to DY* core)