### PR TITLE
Added Responder Authentication to Online Protocol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ INNER_SOURCE_DIRS = dy-extensions
 # SOURCE_DIRS = $(addprefix $(DY_HOME)/src/, $(INNER_SOURCE_DIRS))
 SOURCE_DIRS = $(addprefix $(TUTORIAL_HOME)/, $(INNER_SOURCE_DIRS))
 
-INNER_EXAMPLE_DIRS = nsl_pk_only_one_event_lookup TwoMessageP Online Online_with_secrecy
+INNER_EXAMPLE_DIRS = nsl_pk_only_one_event_lookup TwoMessageP Online Online_with_secrecy Online_with_authn
 EXAMPLE_DIRS ?= $(addprefix $(TUTORIAL_HOME)/examples/, $(INNER_EXAMPLE_DIRS))
 
 

--- a/dy-extensions/DY.Extend.fst
+++ b/dy-extensions/DY.Extend.fst
@@ -5,6 +5,20 @@ open DY.Core
 open DY.Lib
 open DY.Core.Trace.Base
 
+
+val is_secret_is_knowable:
+  {|cinvs: crypto_invariants|} -> l:label -> tr:trace -> b:bytes ->
+  Lemma 
+  (requires is_secret l tr b)
+  (ensures is_knowable_by l tr b)
+  [SMTPat (is_secret #cinvs l tr b)]
+let is_secret_is_knowable #_ l tr b
+  = ()
+
+let rand_generated_before tr b = 
+  exists ts. rand_generated_at tr ts b
+
+
 let core_state_was_set_grows  tr1 tr2 prin sid cont:
   Lemma 
   (requires
@@ -36,19 +50,19 @@ let state_was_set_grows (#a:Type) {|ls:local_state a|} tr1 tr2 prin sid (cont : 
 let state_was_set_some_id (#a:Type) {|local_state a|} tr prin (cont : a) =
   exists sid. DY.Lib.state_was_set tr prin sid cont
 
-// val state_was_set_some_id_grows:
-//   #a:Type -> {|lsa:local_state a|} ->
-//   tr1:trace -> tr2:trace -> 
-//   prin:principal -> content:a ->
-//   Lemma
-//   (requires tr1 <$ tr2
-//     /\ state_was_set_some_id tr1 prin content
-//   )
-//   (ensures
-//     state_was_set_some_id tr2 prin content
-//   )
-//   [SMTPat (state_was_set_some_id #a #lsa tr1 prin content); SMTPat (tr1 <$ tr2)]
-// let state_was_set_some_id_grows #a #ls tr1 tr2 prin content  = ()
+val state_was_set_some_id_grows:
+  #a:Type -> {|lsa:local_state a|} ->
+  tr1:trace -> tr2:trace -> 
+  prin:principal -> content:a ->
+  Lemma
+  (requires tr1 <$ tr2
+    /\ state_was_set_some_id tr1 prin content
+  )
+  (ensures
+    state_was_set_some_id tr2 prin content
+  )
+  [SMTPat (state_was_set_some_id #a #lsa tr1 prin content); SMTPat (tr1 <$ tr2)]
+let state_was_set_some_id_grows #a #ls tr1 tr2 prin content  = admit()
 
 
 /// Lookup the most recent state of a principal satisfying some property.

--- a/dy-extensions/DY.Extend.fst
+++ b/dy-extensions/DY.Extend.fst
@@ -64,9 +64,8 @@ val state_was_set_some_id_grows:
     state_was_set_some_id tr2 prin content
   )
   [SMTPat (state_was_set_some_id #a #lsa tr1 prin content); SMTPat (tr1 <$ tr2)]
-let state_was_set_some_id_grows #a #ls tr1 tr2 prin content  = admit()
-
-
+let state_was_set_some_id_grows #a #ls tr1 tr2 prin content  = 
+  assert(exists sid. DY.Lib.state_was_set tr1 prin sid content)
 
 val empty_invariants:
   {| protocol_invariants |} ->

--- a/examples/Online_with_authn/DY.OnlineA.Authn.fst
+++ b/examples/Online_with_authn/DY.OnlineA.Authn.fst
@@ -1,0 +1,25 @@
+module DY.OnlineA.Authn
+
+open Comparse
+open DY.Core
+open DY.Lib
+
+open DY.Extend
+
+open DY.OnlineA.Data
+open DY.OnlineA.Invariants
+
+val authn:
+  tr:trace -> 
+  alice:principal -> bob:principal ->
+  n_a:bytes ->
+  Lemma
+  (requires
+     trace_invariant tr /\
+     state_was_set_some_id tr alice (ReceivedAck {bob; n_a})
+  )
+  (ensures
+     is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob) \/
+     state_was_set_some_id tr bob (SendingAck {alice; n_a})
+  )
+let authn tr alice bob n_a = ()

--- a/examples/Online_with_authn/DY.OnlineA.Authn.fst
+++ b/examples/Online_with_authn/DY.OnlineA.Authn.fst
@@ -9,6 +9,12 @@ open DY.Extend
 open DY.OnlineA.Data
 open DY.OnlineA.Invariants
 
+/// This is the new property, we want to show:
+/// if Alice finishes a run identified by Bob and a nonce n_a,
+/// then this Bob was involved in the run,
+/// i.e., Bob sent n_a in an acknowledgement to Alice.
+/// Unless one of Alice or Bob are corrupt.
+
 val authn:
   tr:trace -> 
   alice:principal -> bob:principal ->
@@ -23,3 +29,20 @@ val authn:
      state_was_set_some_id tr bob (SendingAck {alice; n_a})
   )
 let authn tr alice bob n_a = ()
+
+
+/// We still have nonce secrecy:
+
+val n_a_secrecy:
+  tr:trace -> alice:principal -> bob:principal -> n_a:bytes ->
+  Lemma
+  (requires
+    attacker_knows tr n_a /\
+    trace_invariant tr /\ (
+      (exists sess_id. state_was_set tr alice sess_id (SendingPing {bob; n_a})) \/
+      (exists sess_id. state_was_set tr alice sess_id (ReceivedAck {bob; n_a} ))
+    )
+  )
+  (ensures is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob))
+let n_a_secrecy tr alice bob n_a =
+  attacker_only_knows_publishable_values tr n_a

--- a/examples/Online_with_authn/DY.OnlineA.Data.fst
+++ b/examples/Online_with_authn/DY.OnlineA.Data.fst
@@ -1,0 +1,163 @@
+module DY.OnlineA.Data
+
+open Comparse
+open DY.Core
+open DY.Lib
+
+/// Here, we define the abstract types for the "Online?" Protocol:
+///
+/// A -> B: enc{Ping (A, n_A)}_B
+/// B -> A: enc{Ack n_A}_A
+///
+/// (They are the same as for the simple 2 message protocol)
+
+(*** Message Type ***)
+
+/// for each of the two messages we define an abstract message type
+
+[@@ with_bytes bytes] // ignore this line for now
+type ping_t = {
+  alice: principal;
+  n_a : bytes;
+}
+
+[@@ with_bytes bytes] // ignore this line for now
+type ack_t = {
+  n_a : bytes;
+}
+
+/// the overall abstract message type
+/// (consisting of constructors for the two messages
+/// and using the above abstract types for each of them)
+
+[@@ with_bytes bytes] // ignore this line for now
+type message_t =
+  | Ping: (ping:ping_t) -> message_t
+  | Ack: (ack:ack_t) -> message_t
+
+
+/// We use Comparse to generate the corresponding message formats.
+/// I.e., we don't need to write parsing and serializing by hand
+///
+/// for this we need the `[@@ with_bytes bytes]` annotation for the message types above
+///
+/// We are not going into the details of how Comparse works.
+
+
+/// We let Comparse generate a parser `ps_ping_t` for the abstract `ping_t` type
+
+%splice [ps_ping_t] (gen_parser (`ping_t))
+
+/// ... and the same for the other abstract message types
+
+%splice [ps_ack_t] (gen_parser (`ack_t))
+
+%splice [ps_message_t] (gen_parser (`message_t))
+
+/// With the above parsers, we can make our `message` type an instance of
+/// Comparse's `parseable_serializeable` class.
+/// Again, the details are not important here,
+/// but this is the step that enables us to call
+/// `parse message buff` and `serialize message msg`
+/// to translate between bytes and our abstract message type.
+
+instance parseable_serializeable_bytes_message_t: parseable_serializeable bytes message_t = mk_parseable_serializeable ps_message_t
+
+
+(*** State Type ***)
+
+/// As for the messages we define abstract state types
+/// for the three states stored by Alice and Bob after each step of the protocol.
+
+[@@ with_bytes bytes]
+type sent_ping_t = {
+  bob : principal;
+  n_a : bytes;
+}
+
+[@@ with_bytes bytes]
+type sent_ack_t = {
+  alice: principal;
+  n_a : bytes;
+}
+
+[@@ with_bytes bytes]
+type received_ack_t = {
+  bob : principal;
+  n_a : bytes;
+}
+
+[@@ with_bytes bytes]
+type state_t = 
+  | SendingPing: (ping:sent_ping_t) -> state_t
+  | SendingAck: (ack:sent_ack_t) -> state_t
+  | ReceivedAck: (rack:received_ack_t) -> state_t
+
+/// As for messages, we use Comparse to generate
+/// a parser and serializer for our abstract state types.
+
+%splice [ps_sent_ping_t] (gen_parser (`sent_ping_t))
+%splice [ps_sent_ack_t] (gen_parser (`sent_ack_t))
+%splice [ps_received_ack_t] (gen_parser (`received_ack_t))
+%splice [ps_state_t] (gen_parser (`state_t))
+
+/// Now, we can call
+/// `parse state buff` and `serialize state st`
+/// to translate between bytes and the abstract state type.
+
+instance parseable_serializeable_bytes_state_t: parseable_serializeable bytes state_t = mk_parseable_serializeable ps_state_t
+
+/// We tag our protocol level states,
+/// so that they are distinguishable from any internal DY* states. 
+
+instance local_state_state: local_state state_t = {
+  tag = "P.State";
+  format = parseable_serializeable_bytes_state_t;
+}
+
+(*** PKI ***)
+
+/// For en-/de-cryption we assume some PKI.
+/// I.e., every participant has some private decryption keys
+/// and some public encryption keys from other participants.
+/// All private keys of a participant will be stored in one session
+/// and all public keys that the participant knows will be stored in another session.
+/// For each participant, we collect both these session IDs in a global record.
+
+type global_sess_ids = {
+  pki: state_id;
+  private_keys: state_id;
+}
+
+/// Similarly as for states,
+/// we tag the keys that are used on the protocol level,
+/// so that they can not be confused with other keys.
+/// (TODO: rephrase this)
+
+let key_tag = "P.Key"
+
+
+(*** Event type ***)
+
+/// Type for the NSL protocol events.
+/// They will be used to write authentication security properties.
+
+[@@ with_bytes bytes]
+type ev_init_t = {
+  alice:principal;
+  bob:principal;
+  n_a:bytes
+}
+%splice [ps_ev_init_t] (gen_parser (`ev_init_t))
+
+[@@ with_bytes bytes]
+type event_t =
+  | Initiating: ev_init_t -> event_t
+
+%splice [ps_event_t] (gen_parser (`event_t))
+%splice [ps_event_t_is_well_formed] (gen_is_well_formed_lemma (`event_t))
+
+instance event_event_t: event event_t = {
+  tag = "P.Event";
+  format = mk_parseable_serializeable ps_event_t;
+}

--- a/examples/Online_with_authn/DY.OnlineA.Data.fst
+++ b/examples/Online_with_authn/DY.OnlineA.Data.fst
@@ -67,7 +67,8 @@ instance parseable_serializeable_bytes_message_t: parseable_serializeable bytes 
 (*** State Type ***)
 
 /// As for the messages we define abstract state types
-/// for the three states stored by Alice and Bob after each step of the protocol.
+/// for the three states stored by Alice and Bob in each step of the protocol.
+///
 
 [@@ with_bytes bytes]
 type sent_ping_t = {
@@ -87,6 +88,13 @@ type received_ack_t = {
   n_a : bytes;
 }
 
+/// ATTENTION: We are now storing the states
+/// not at the *end* of the step (as in the model for the secrecy property) but
+/// in the beginning of the steps, i.e., before sending the corresponding messages.
+/// To make this difference more clear,
+/// we rename the state constructors from "Sent" to "Sending"
+/// with the intuition of "about to send".
+ 
 [@@ with_bytes bytes]
 type state_t = 
   | SendingPing: (ping:sent_ping_t) -> state_t
@@ -139,9 +147,13 @@ let key_tag = "P.Key"
 
 (*** Event type ***)
 
-/// Type for the NSL protocol events.
-/// They will be used to write authentication security properties.
+/// We are now using an event to show the authentication property
+/// and define an abstract event type
+/// just as for messages and states.
 
+/// The event is used to store (on the trace)
+/// that alice started a run with bob
+/// using the nonce n_a.
 [@@ with_bytes bytes]
 type ev_init_t = {
   alice:principal;

--- a/examples/Online_with_authn/DY.OnlineA.Invariants.Proofs.fst
+++ b/examples/Online_with_authn/DY.OnlineA.Invariants.Proofs.fst
@@ -1,0 +1,500 @@
+module DY.OnlineA.Invariants.Proofs
+
+open Comparse
+open DY.Core
+open DY.Lib
+
+open DY.Simplified
+open DY.Extend
+
+open DY.OnlineA.Data
+open DY.OnlineA.Protocol
+open DY.OnlineA.Invariants
+
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 25  --z3cliopt 'smt.qi.eager_threshold=100'"
+
+/// In this module, we show that
+/// the three protocol steps (send_ping, receive_ping_and_send_ack, and receive_ack)
+/// maintain the protocol invariants.
+///
+/// For every step s we show a lemma of the form:
+/// trace_invariant tr ==> trace_invariant ( trace after step s )
+
+
+(*** Sending a Ping maintains the invariants ***)
+
+
+/// The invariant lemma for the first step `send_ping`
+
+val send_ping_invariant:
+  alice:principal -> bob:principal -> keys_sid:state_id ->
+  tr:trace ->
+  Lemma
+  ( requires trace_invariant tr
+  )
+  (ensures (
+    let (_ , tr_out) = send_ping alice bob keys_sid tr in
+    trace_invariant tr_out
+  ))
+(* The proof works by showing that the trace invariant is maintained
+   by every traceful action in the step.
+   So we replicate the actions of the step and show trace_invariant after each.
+   
+   (Note that we are now in the "Lemma context",
+   so we have to unfold the monadic lets and sequences.)
+*)
+let send_ping_invariant alice bob keys_sid  tr =
+  (* The first action is generating the nonce n_a.
+  
+     Note that we can't use let* here since we are not in the traceful monad.
+     Thus, we have to pass the trace `tr` explicitly as last argument.
+     And we get back the new trace `tr_rand`.
+  *)
+  let (n_a, tr_rand) = gen_rand_labeled (nonce_label alice bob) tr in
+  (* That the trace invariant holds after this action,
+     can be shown automatically.
+
+     There is a corresponding lemma in `DY.Core.Trace.Manipulation`:
+     `mk_rand_trace_invariant`.
+     It comes with an SMT Pattern an hence is applied automatically.
+  *)
+  assert(trace_invariant tr_rand);
+
+  let (_, tr_ev) = trigger_event alice (Initiating {alice; bob; n_a}) tr_rand in
+
+  // Defining the abstract message does not change the trace,
+  // so we don't have to show anything.
+  let ping = Ping {alice; n_a} in 
+
+ (* The last traceful action in this step is starting a new session *)
+      let st = SendingPing {bob; n_a} in
+      let (sid, tr_sess) = start_new_session alice st tr_ev in
+      (* `start_new_session` is just calling `new_session_id` and then `set_state`.
+         So we have to check that both of those maintain the trace invariant.
+
+         For `new_session_id` we find the lemma 
+         `new_session_id_same_trace` in `DY.Core.Trace.Manipulation`
+         which says that the trace is not changed.
+         Hence it trivially maintains the trace invariant.
+         It comes with an SMT pattern, so it is applied automatically.
+
+         In the same file, we have the lemma `set_state_invariant`,
+         which gives an additional pre-condition 
+         for when the trace after the state was set satisfies the trace invariant.
+         This pre-condition is that the new state must satisfy the state predicate.
+
+         The state predicate for the SendingPing state requires that
+         the nonce stored in the state has the label `nonce_label alice' bob'`, where
+         * alice' is the storing principal
+         * bob' is the name stored in the first component of the state
+
+         Similarly to above,
+         we generated the nonce wit the label `nonce_label alice bob` and
+         alice is storing the new state, and
+         bob is stored in the first component of the state.
+         So the state prediate is satisfied:
+      *)
+      assert(state_predicate_p.pred tr_ev alice sid st);
+      (* With this, we have all pre-conditions of `set_state_invariant`.
+         Since that lemma comes with an SMT pattern,
+         it is applied automatically.
+      *)
+      assert(trace_invariant tr_sess);
+
+  (* The call of `pke_enc_for` in the traceful + option monad 
+     has to be unfolded:
+     * We pass the current trace `tr_rand` as las argument
+     * We need to make a case distinction on the resulting option
+       and show trace_invariant in each case separately
+  *)
+  match pke_enc_for alice bob keys_sid key_tag ping tr_sess with
+  | (None, _) -> ( 
+      (* If encryption fails, the trace is not changed,
+         and hence the resulting trace after send_ping is tr_rand.
+         Since we already showed trace_invariant for tr_rand,
+         we don't have to show anything else in this case.
+
+        If you want to check this,
+        you can uncomment the next lines
+      *)
+      // let (_ , tr_out) = send_ping alice bob keys_sid tr in 
+      // assert(tr_out == tr_rand);
+      // assert(trace_invariant tr_out);
+      ()
+    )
+  | (Some ping_encrypted, tr_enc) -> (
+      (* If encryption succeeds, we get a new trace `tr_enc`.
+         With the lemma `pke_enc_for_invariant` in `DY.Simplified`,
+         we have that trace_invariant holds for tr_enc.
+
+         Observe, that this lemma can be shown automatically.
+         Hence, we don't even have to call it here.
+      *)
+      assert(trace_invariant tr_enc);
+
+      (* The next traceful action is sending the encrypted message.
+
+         Again, we have to pass the current trace `tr_enc` as last argument.
+      *)
+      let (msg_ts, tr_msg) = send_msg ping_encrypted tr_enc in
+      (* To show trace_invariant after sending the message (for `tr_msg`),
+         we look at the lemma `send_msg_invariant` in `DY.Core.Trace.Manipulation`
+         which looks very promising.
+         However, that lemma has an additional pre-condition requiring that
+         the message needs to be publishable.
+         (That corresponds to the intuition that everything on the trace 
+         is readable by the attacker.)
+
+         So to call this lemma, we have to show `is_publishable tr_enc ping_encrypted`.
+         Looking at `DY.Simplified`, we find the lemma `pke_enc_for_is_publishable`,
+         which gives a bunch of pre-conditions for the plaintext (serialized `ping`) 
+         under which the ciphertext `ping_encrypted` is publishable.
+         We show each of those pre-conditions.
+      *)
+          (* The first is `has_pki_invariant`.
+
+             It is a technical requirement on the protocol invariants 
+             which we are not explaining here.
+
+             In `DY.OnlineS.Invariants` we have the lemma `protocol_invariants_p_has_pki_invariant`
+             showing this requirement.
+          *)
+          assert(has_pki_invariant);
+
+          (* The next requirement for `pke_enc_for_is_publishable` is `bytes_invariant tr_enc (serialize ping)`.
+
+             TODO              
+          *)
+          serialize_wf_lemma message_t (is_knowable_by (nonce_label alice bob) tr_sess) ping;
+
+          (* The next two pre-conditions say
+             that the serialized ping should be readable by Alice and Bob.
+             (Ignore the `long_term_key_label` for now.)
+
+             TODO: they are resolved with the same serialize_wf_lemma
+          *)
+
+          (* Finally, we need to show the disjunction of
+             * the pke_pred holds for the serialized ping or
+             * the serialized ping is publishable
+
+             In our case, the first is true, i.e., the encryption prediate is satisfied.
+             The predicate requires that the nonce contained in the ping
+             has the label `nonce_label alice' bob'`, where
+             * alice' is the name in the first component of the ping and
+             * bob' is the participant whos key is used for encryption.
+
+             Since we generate the nonce n_a in the beginning of this step
+             with the label `nonce_label alice bob`,
+             put the same alice in the first component of the ping
+             and use the key of bob for encryption (in pke_enc_for),
+             we satisfy the predicate.
+          *)
+          assert(pke_pred.pred tr_sess (long_term_key_type_to_usage (LongTermPkeKey key_tag) bob) (serialize message_t ping));
+      (* Now we showed all pre-conditions of `pke_enc_for_is_publishable`
+         and can call this lemma to show that ping_encrypted is publishable.
+
+         Together with the `send_msg_invariant` lemma, 
+         we then obtain that `tr_msg` satisfies the trace invariant.
+      *)
+      pke_enc_for_is_publishable tr_sess alice bob keys_sid key_tag ping;
+      assert(trace_invariant tr_msg);
+
+   ()  
+  )
+
+(* The above proof was very detailed.
+   In fact, most of the proof is done automatically by F*
+   and we can remove all of the asserts.
+
+   If we just keep the necessary calls to lemmas,
+   we end up with the following very short proof.
+*)
+val send_ping_invariant_short_version:
+  alice:principal -> bob:principal -> keys_sid:state_id ->
+  tr:trace ->
+  Lemma
+  ( requires trace_invariant tr
+  )
+  (ensures (
+    let (_ , tr_out) = send_ping alice bob keys_sid tr in
+    trace_invariant tr_out
+  ))
+let send_ping_invariant_short_version alice bob keys_sid  tr =
+  let (n_a, tr_rand) = gen_rand_labeled (nonce_label alice bob) tr in
+  let (_, tr_ev) = trigger_event alice (Initiating {alice; bob; n_a}) tr_rand in
+  let (_, tr_sess) = start_new_session alice (SendingPing {bob; n_a}) tr_ev in  
+  let ping = Ping {alice; n_a} in 
+  serialize_wf_lemma message_t (is_knowable_by (nonce_label alice bob) tr_sess) ping;
+  pke_enc_for_is_publishable tr_sess alice bob keys_sid key_tag ping
+
+
+(*** Replying to a Ping maintains the invariants ***)
+
+
+(* For the second protocol step (`receive_ping_and_send_ack`),
+   we need a helper lemma: `decode_ping_proof`.
+
+   Ignore this for now, and jump to the next lemma 
+   `receive_ping_and_send_ack_invariant`
+*)
+
+val decode_ping_proof:
+  tr:trace ->
+  bob:principal -> keys_sid:state_id ->
+  msg:bytes ->
+  Lemma
+  (requires (
+    trace_invariant tr
+    /\ bytes_invariant tr msg
+  ))
+  (ensures (
+    match decode_ping bob keys_sid msg tr with
+    | (None, _) -> True
+    | (Some png, _) -> (
+        let n_a = png.n_a in
+        bytes_invariant tr n_a /\
+        is_knowable_by (nonce_label png.alice bob) tr n_a /\
+        ( is_publishable tr n_a
+        \/ (pke_pred.pred tr (long_term_key_type_to_usage (LongTermPkeKey key_tag) bob) (serialize message_t (Ping png)))
+        )
+    )
+  ))
+let decode_ping_proof tr bob keys_sid msg =
+    match decode_ping bob keys_sid msg tr with
+    | (None, _) -> ()
+    | (Some png, _) -> (
+        bytes_invariant_pke_dec_with_key_lookup tr #message_t #parseable_serializeable_bytes_message_t bob keys_sid key_tag msg;
+        let plain = serialize message_t (Ping png) in
+        parse_wf_lemma message_t (bytes_invariant tr) plain;
+        FStar.Classical.move_requires (parse_wf_lemma message_t (is_publishable tr)) plain
+    )
+  
+
+
+/// The invariant lemma for the `receive_ping_and_send_ack` step
+
+val receive_ping_and_send_ack_invariant:
+  bob:principal -> keys_sid:global_sess_ids -> ts:timestamp ->
+  tr:trace ->
+  Lemma
+  ( requires trace_invariant tr
+  )
+  (ensures (
+    let (_ , tr_out) = receive_ping_and_send_ack bob keys_sid ts tr in
+    trace_invariant tr_out
+  ))
+let receive_ping_and_send_ack_invariant bob bob_keys_sid msg_ts tr =
+  (* As for the first protocol step,
+     we need to show that every traceful action 
+     maintains the trace invariant.
+  *)
+  match recv_msg msg_ts tr with // unfold the traceful + option let
+  | (None, _ ) -> () // in this case the trace is not changed and hence the trace invariant is trivially satisfied
+  | (Some msg, _) -> (
+      (* From the lemma `recv_msg_same_trace` in `DY.Core.Trace.Manipulation` 
+         we have that the receive function does not change the trace
+         and hence the trace invariant is still satisfied. *)
+      match decode_ping bob bob_keys_sid.private_keys msg tr with // unfold the next monadic let
+      | (None, _) -> () // Again, if decoding fails, the trace is not changed and hence nothing left to show
+      | (Some png, _) -> (
+          (* Decoding the ping message does not change the trace.
+             So we are still working on the input trace tr,
+             for which we know the trace invariant.
+
+             That decoding doesn't change the trace,
+             is shown automatically 
+             with corresponding SMT patterns for the individual steps of the function.
+             I.e., try uncommenting the following lemma:
+           *) 
+             // let decode_ping_same_trace
+             //    (p:principal) (keys_sid:state_id) (msg:bytes) (tr:trace) :
+             //    Lemma (
+             //       let (_, tr_out) = decode_ping p keys_sid msg tr in
+             //       tr_out == tr )
+             //    = () in
+          
+          let n_a = png.n_a in
+          let alice = png.alice in
+          
+          let ack = Ack {n_a} in
+
+ (* As in the first protocol step,
+                   starting a new session maintains the trace invariant,
+                   if the new state satisfies the state predicate.
+
+                   For the new SendingAck state, this means that
+                   the stored nonce
+                   must be readble by
+                   the storing principal (here bob).
+
+                   We get this property from our helper lemma `decode_ping_proof`.
+                *)
+                let st = (SendingAck {alice = png.alice; n_a = png.n_a}) in
+                let (sess_id, tr_sess) = start_new_session bob st tr in
+                                  decode_ping_proof tr bob bob_keys_sid.private_keys msg;
+
+                assert(trace_invariant tr_sess);
+
+          match pke_enc_for bob alice bob_keys_sid.pki key_tag ack tr_sess with
+          | (None, _) -> ()
+          | (Some ack_encrypted, tr_ack) ->(
+                (* As before, encryption maintains the trace invariant 
+                   (see `pke_enc_for_invariant` in `DY.simplified`) *)
+                assert(trace_invariant tr_ack);
+
+                let (ack_ts, tr_msg) = send_msg ack_encrypted tr_ack in
+                (* The same as in the first protocol step:
+                   we want to use the lemma `send_msg_invariant` from `DY.Core.Trace.Manipulation`
+                   to show that sending the encrypted ack maintains the invariant.
+
+                   For this, we need to show that the encrypted ack is publishable.
+                   Again, we want to apply the lemma `pke_enc_for_is_publishable` from `DY.Simplified`.
+                   So we have to show all of the pre-conditions of this lemma.
+                *)
+                  (* `trace_invariant tr` and `has_pki_invariant` are satisfied *)
+                  (* For `bytes_invariant` of the serialized ack,
+                     we need a helper lemma.
+
+                     TODO ....
+                  *)
+                  decode_ping_proof tr bob bob_keys_sid.private_keys msg;
+                  serialize_wf_lemma message_t (bytes_invariant tr) (ack);
+                  assert(bytes_invariant tr (serialize message_t ack));
+                  
+                  (* From this helper lemma, we also get
+                     that the nonce is readable by alice and bob.
+
+                     We use this fact together with a comparse lemma,
+                     to show the next two requirements:
+                     the serialized ack is readable by alice and bob 
+                     (again ignoring the `long_term_key_label`) *)
+                  assert(is_knowable_by (nonce_label alice bob) tr n_a);
+                  serialize_wf_lemma message_t (is_knowable_by (nonce_label alice bob) tr) ack;
+
+                  (* The final requirement is trivially satisfied, 
+                     since the pke_pred for an Ack is just True
+
+                     You can check:
+                     assert(pke_pred.pred tr (long_term_key_type_to_usage (LongTermPkeKey key_tag) alice) (serialize message_t ack));
+                  *)
+                (* Thus, we can call `pke_enc_for_is_publishable`
+                   to get the missing pre-condition for `send_msg_invariant`.*)
+                pke_enc_for_is_publishable tr_sess bob alice bob_keys_sid.pki key_tag ack;
+                assert(trace_invariant tr_msg);
+
+               ()
+           )
+      )
+  )
+
+
+
+(*** Receiving an Ack maintains the invariants ***)
+
+val decode_ack_proof:
+  tr:trace ->
+  alice:principal -> keys_sid:state_id ->
+  msg:bytes ->
+  Lemma
+  (requires (
+    trace_invariant tr
+    /\ bytes_invariant tr msg
+  ))
+  (ensures (
+    match decode_ack alice keys_sid msg tr with
+    | (None, _) -> True
+    | (Some ack, _) -> (
+        let n_a = ack.n_a in
+        bytes_invariant tr n_a /\
+        //is_knowable_by (principal_label alice) tr n_a /\
+        ( is_publishable tr n_a
+        \/ (pke_pred.pred tr (long_term_key_type_to_usage (LongTermPkeKey key_tag) alice) (serialize message_t (Ack ack)))
+        )
+    )
+  ))
+let decode_ack_proof tr alice keys_sid msg =
+    match decode_ack alice keys_sid msg tr with
+    | (None, _) -> ()
+    | (Some ack, _) -> (
+        bytes_invariant_pke_dec_with_key_lookup tr #message_t #parseable_serializeable_bytes_message_t alice keys_sid key_tag msg;
+        let plain = serialize message_t (Ack ack) in
+        parse_wf_lemma message_t (bytes_invariant tr) plain;
+        FStar.Classical.move_requires (parse_wf_lemma message_t (is_publishable tr)) plain
+        
+    )
+  
+
+
+/// The invariant lemma for the final protocol step `receive_ack_invariant`
+
+
+val event_respond1_injective:
+  tr:trace ->
+  alice:principal -> bob:principal -> bob':principal ->
+  n_a:bytes ->
+  Lemma
+  (requires
+    trace_invariant tr /\
+    event_triggered tr alice (Initiating {alice; bob; n_a} ) /\
+    event_triggered tr alice (Initiating {alice; bob =bob'; n_a} )
+  )
+  (ensures
+    bob == bob'
+  )
+let event_respond1_injective tr alice bob bob' n_a = ()
+
+
+#push-options "--ifuel 2"
+val receive_ack_invariant:
+  alice:principal -> keys_sid:state_id -> msg_ts:timestamp ->
+  tr:trace ->
+  Lemma
+  (requires
+    trace_invariant tr
+  )
+  (ensures (
+    let (_, tr_out) = receive_ack alice keys_sid msg_ts tr in
+    trace_invariant tr_out
+  ))
+(* The proof for this last step is automatic. *)
+let receive_ack_invariant alice keys_sid msg_ts tr =
+  match recv_msg msg_ts tr with
+  | (None, _) -> ()
+  | (Some msg, _) -> (
+      match decode_ack alice keys_sid msg tr with
+      | (None, _) -> ()
+      | (Some ack, _) -> (
+          let n_a = ack.n_a in
+          let p = (fun (st:state_t) -> SendingPing? st && (SendingPing?.ping st).n_a = n_a) in
+          match lookup_state #state_t alice p tr with
+          | (None, _) -> ()
+          | (Some (st, sid), _) -> (
+              let bob = (SendingPing?.ping st).bob in
+              let newst = ReceivedAck {bob; n_a} in
+
+              let ((), tr_st) = set_state alice sid newst tr in
+
+              assert(event_triggered tr alice (Initiating {alice; bob;n_a}));
+              assert(is_secret (nonce_label alice bob) tr n_a);
+              assert(is_publishable tr n_a ==> is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob));
+              introduce ~(is_publishable tr n_a) ==> 
+            state_was_set_some_id tr bob (SendingAck {alice; n_a} )
+            with _. (
+              decode_ack_proof tr alice keys_sid msg;
+              assert(pke_pred.pred tr (long_term_key_type_to_usage (LongTermPkeKey key_tag) alice) (serialize message_t (Ack ack)));
+              eliminate exists bob'. get_label tr n_a `can_flow tr` (principal_label bob') /\ 
+              state_was_set_some_id tr bob' (SendingAck {alice; n_a} )
+              returns _
+              with _. (
+                assert(event_triggered tr alice (Initiating {alice; bob = bob'; n_a} ));
+                event_respond1_injective tr alice bob bob' n_a
+              
+              )
+
+            );
+              assert(trace_invariant tr_st)
+          )
+      )
+  )
+#pop-options

--- a/examples/Online_with_authn/DY.OnlineA.Invariants.Proofs.fst
+++ b/examples/Online_with_authn/DY.OnlineA.Invariants.Proofs.fst
@@ -49,6 +49,20 @@ let send_ping_invariant_short_version alice bob keys_sid  tr =
 
 (*** Replying to a Ping maintains the invariants ***)
 
+
+val decode_ping_invariant:
+  bob:principal -> keys_sid:state_id ->
+  msg:bytes ->
+  tr:trace ->
+  Lemma
+  (requires trace_invariant tr)
+  (ensures (
+    let (_, tr_out) = decode_ping bob keys_sid msg tr in
+    trace_invariant tr_out
+  ))
+let decode_ping_invariant bob keys_sid msg tr = ()
+
+
 val decode_ping_proof:
   tr:trace ->
   bob:principal -> keys_sid:state_id ->
@@ -157,6 +171,20 @@ let receive_ping_and_send_ack_invariant bob bob_keys_sid msg_ts tr =
 
 
 (*** Receiving an Ack maintains the invariants ***)
+
+
+val decode_ack_invariant:
+  alice:principal -> keys_sid:state_id -> cipher:bytes ->
+  tr:trace ->
+  Lemma
+  (requires
+    trace_invariant tr
+  )
+  (ensures (
+    let (_, tr_out) = decode_ack alice keys_sid cipher tr in
+    trace_invariant tr_out
+  ))
+let decode_ack_invariant alice keys_sid msg tr = ()
 
 
 /// Since we now have a non-trivial property for the ReceivedAck state,

--- a/examples/Online_with_authn/DY.OnlineA.Invariants.Proofs.fst
+++ b/examples/Online_with_authn/DY.OnlineA.Invariants.Proofs.fst
@@ -257,22 +257,6 @@ val event_initiating_injective:
   )
 let event_initiating_injective tr alice bob bob' n_a = ()
 
-val event_initiating_injective_:
-  tr:trace ->
-  alice:principal -> alice':principal -> bob:principal -> bob':principal ->
-  n_a:bytes ->
-  Lemma
-  (requires
-    trace_invariant tr /\
-    event_triggered tr alice (Initiating {alice; bob; n_a} ) /\
-    event_triggered tr alice' (Initiating {alice =alice'; bob =bob'; n_a} )
-  )
-  (ensures
-    alice == alice' /\
-    bob == bob'
-  )
-let event_initiating_injective_ tr alice alice' bob bob' n_a = ()
-
 
 /// The invariant lemma for the final protocol step `receive_ack_invariant`
 

--- a/examples/Online_with_authn/DY.OnlineA.Invariants.Proofs.fst
+++ b/examples/Online_with_authn/DY.OnlineA.Invariants.Proofs.fst
@@ -193,14 +193,13 @@ let decode_ack_proof tr alice keys_sid msg =
         let plain = serialize message_t (Ack ack) in
         parse_wf_lemma message_t (bytes_invariant tr) plain;
         FStar.Classical.move_requires (parse_wf_lemma message_t (is_publishable tr)) plain
-        
     )
   
 
 /// Additionally,
 /// we need an injectivity lemma.
 /// The goal is to show that Alice uses the nonces n_a
-/// only once, i.e., the nonce n_a are unique for every run.
+/// only once, i.e., the nonces n_a are unique for every run.
 ///
 /// We show this with the help of the Initiating event:
 /// If there are two events triggered by the same Alice
@@ -223,7 +222,7 @@ val event_initiating_injective:
   (requires
     trace_invariant tr /\
     event_triggered tr alice (Initiating {alice; bob; n_a} ) /\
-    event_triggered tr alice (Initiating {alice; bob =bob'; n_a} )
+    event_triggered tr alice (Initiating {alice; bob = bob'; n_a} )
   )
   (ensures
     bob == bob'
@@ -304,7 +303,8 @@ let receive_ack_invariant alice keys_sid msg_ts tr =
                   // from the state predicate of the looked up SendingPing state of Alice:
                   assert(event_triggered tr alice (Initiating {alice; bob;n_a}));
 
-                  // from the state predicate of the SendingAck state of bob':
+                  // from the state predicate of the SendingAck state of bob'
+                  // (via the state prediate for the SendinPing state of Alice with bob'):
                   assert(event_triggered tr alice (Initiating {alice; bob = bob'; n_a} ));
 
                   // the injectivity lemma from above, yields bob' = bob

--- a/examples/Online_with_authn/DY.OnlineA.Invariants.fst
+++ b/examples/Online_with_authn/DY.OnlineA.Invariants.fst
@@ -1,0 +1,263 @@
+module DY.OnlineA.Invariants
+
+open Comparse 
+open DY.Core
+open DY.Lib
+
+open DY.Extend
+
+open DY.OnlineA.Data
+open DY.OnlineA.Protocol
+
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 25"
+
+/// In this module, we define the protocol invariants.
+/// They consist of
+/// * crypto invariants and
+/// * trace invariants which in turn consist of
+///   * state invariants and
+///   * event invariants
+///
+/// We then have to show
+/// * these invariants imply the secrecy property (see DY.OnlineS.Secrecy) and
+/// * every protocol step maintains these invariants (see DY.OnlineS.Invariants.Proofs)
+/// With this, we then know that
+/// the protocol model satisfies the secrecy property.
+
+
+(*** Crypto Invariants ***)
+
+
+(** TODO **)
+// needed for `crypto_prediates.pke_pred.pred_later`
+%splice [ps_ping_t_is_well_formed] (gen_is_well_formed_lemma (`ping_t))
+%splice [ps_ack_t_is_well_formed] (gen_is_well_formed_lemma (`ack_t))
+%splice [ps_message_t_is_well_formed] (gen_is_well_formed_lemma (`message_t))
+
+
+
+// ignore this for now
+instance crypto_usages_p : crypto_usages = default_crypto_usages
+
+#push-options "--ifuel 2"
+let crypto_p : crypto_predicates = { 
+  default_crypto_predicates with 
+  (* we restrict when a message is allowed to be encrypted 
+     with some secret key
+
+     Or put differently:
+     What are the guarantees that an honest sender can provide
+     that are available at the receiver after decryption?
+  *)
+  pke_pred = { 
+    pred = (fun tr sk_usage msg ->
+    exists prin. // the intended receiver of the message
+    (
+      // needed for `decode_ping_proof` [Why?]
+      (* the key used for the encryption is
+         a protocol-level public key for the intended receiver (prin) 
+      *)
+      sk_usage == long_term_key_type_to_usage (LongTermPkeKey key_tag) prin /\
+      (match parse message_t msg with
+      | Some (Ping ping) ->
+          (* a Ping message can only be encrypted if
+             (Or: if you decrypt a Ping from an honest party 
+             you get the guarantees that:)
+             the contained nonce n_a
+             is labeled for 
+             * the name provided in the message (alice)
+             * and the intended receiver of the message (bob)
+          *)
+          let bob = prin in
+          let alice = ping.alice in
+          let n_a = ping.n_a in
+          get_label tr n_a == nonce_label alice bob
+          /\ state_was_set_some_id tr alice (SendingPing {bob; n_a})
+      | Some (Ack ack) ->
+          let alice = prin in
+          let n_a = ack.n_a in
+          exists bob.
+          state_was_set_some_id tr bob (SendingAck {alice = prin; n_a = ack.n_a})
+          /\ get_label tr n_a `can_flow tr` principal_label bob
+      | _ -> False // other messages can not be encrypted
+      ))
+      ); 
+    (* a lemma guaranteeing:
+       if the predicate specified above holds for some trace tr1
+       it also holds for any extension tr2 of tr1
+    *)
+    pred_later = (fun tr1 tr2 pk msg -> 
+      parse_wf_lemma message_t (bytes_well_formed tr1) msg
+    ) 
+  } 
+}
+#pop-options
+
+/// Collecting the usages and prediates in the final crypto invariants
+
+instance crypto_invariants_p: crypto_invariants = {
+  usages = crypto_usages_p;
+  preds =  crypto_p
+}
+
+
+(*** State Invariant ***)
+
+// TODO
+// Needed for `state_predicate.pred_knowable`
+%splice [ps_sent_ping_t_is_well_formed] (gen_is_well_formed_lemma (`sent_ping_t))
+%splice [ps_sent_ack_t_is_well_formed] (gen_is_well_formed_lemma (`sent_ack_t))
+%splice [ps_received_ack_t_is_well_formed] (gen_is_well_formed_lemma (`received_ack_t))
+%splice [ps_state_t_is_well_formed] (gen_is_well_formed_lemma (`state_t))
+
+#push-options "--z3cliopt 'smt.qi.eager_threshold=50'"
+(* We restrict what states are allowed to be stored by principals *)
+let state_predicate_p: local_state_predicate state_t = {
+  pred = (fun tr prin sess_id st ->
+    match st with
+    | SendingPing ping -> (
+        (* a SendingPing state may only be stored if
+           the stored nonce is labeled for
+           * the storing principal (alice)
+           * the principal stored in the state 
+             (the intended receiver of the Ping: bob)
+        *) 
+        let alice = prin in
+        let bob = ping.bob in
+        let n_a = ping.n_a in
+        is_secret (nonce_label alice bob) tr n_a
+        /\ event_triggered tr alice (Initiating {alice = alice; bob = bob; n_a = n_a})
+    )
+    | SendingAck ack -> (
+        (* a SendingAck state may only be stored if
+           the stored nonce is readable by
+           the storing principal (bob)
+
+           -- this is a condition that must always hold,
+           and is enforced by the `pred_knowable` Lemma.
+        *)
+        let bob = prin in
+        let n_a = ack.n_a in
+        is_knowable_by (principal_label bob) tr n_a
+        /\ (exists alice.
+          //is_corrupt tr (principal_label alice) \/
+          is_publishable tr n_a \/
+          event_triggered tr alice (Initiating {alice; bob; n_a})
+        )
+    )
+    | ReceivedAck rack  -> (
+        (* a ReceivedAck state may only be stored if
+           the stored nonce is labeled for
+           * the storing principal (alice)
+           * the principal stored in the state
+             (the expected sender of the Ack)
+        *)
+        let alice = prin in
+        let bob = rack.bob in
+        let n_a = rack.n_a in
+        is_knowable_by (principal_label alice) tr n_a /\
+
+        (state_was_set_some_id tr bob (SendingAck {alice; n_a})
+        \/ (is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob)))
+    )
+  );
+  (* as for encryption we have a lemma guaranteeing:
+     if the state predicate holds on some trace tr1
+     it also holds for any extension tr2 of tr2
+  *)
+  pred_later = (fun tr1 tr2 prin sess_id st -> () );
+  (* a lemma guaranteeing that
+     the content of the state to be stored
+     is readable by the storing principal
+  *)
+  pred_knowable = (fun tr prin sess_id st -> 
+    match st with
+    | SendingAck ack -> ()
+    | _ -> ()
+  );
+}
+#pop-options
+
+(*** Event Pred ***)
+
+let event_predicate_event_t: event_predicate event_t =
+  fun tr prin e ->
+    match e with    
+    | Initiating init -> (
+        let alice = init.alice in
+        let bob = init.bob in
+        let n_a = init.n_a in
+        prin == alice /\
+        is_secret (nonce_label alice bob) tr n_a /\
+        0 < DY.Core.Trace.Base.length tr /\
+        rand_generated_at tr (DY.Core.Trace.Base.length tr - 1) n_a
+    )
+
+(*** Trace invariants ***)
+
+// TODO: can this (all_sessions and all_events) be hidden somehow?
+let all_sessions = [
+  pki_tag_and_invariant;
+  private_keys_tag_and_invariant;
+  (|local_state_state.tag, local_state_predicate_to_local_bytes_state_predicate state_predicate_p|);
+]
+
+/// We have no events here,
+/// but we need to specify that for the trace invariants
+let all_events = [(event_event_t.tag, compile_event_pred event_predicate_event_t)]
+
+
+/// The final trace invariants
+/// consisting of
+/// * the state invariant and
+/// * the event invariant
+
+let trace_invariants_p: trace_invariants = {
+  state_pred = mk_state_pred all_sessions;
+  event_pred = mk_event_pred all_events;
+}
+
+
+(*** Protocol Invariants ***)
+
+/// The final protocol invariants
+/// consisting of
+/// * the crypto invariants and
+/// * the trace invariants
+
+instance protocol_invariants_p: protocol_invariants = {
+  crypto_invs = crypto_invariants_p;
+  trace_invs = trace_invariants_p;
+}
+
+
+(*** Helper Lemmas for the Secrecy Proof ***)
+
+// TODO: Can all of this be hidden somehow?
+
+val all_sessions_has_all_sessions: unit -> Lemma (norm [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate) all_sessions))
+let all_sessions_has_all_sessions () =
+  assert_norm(List.Tot.no_repeats_p (List.Tot.map dfst (all_sessions)));
+  mk_state_pred_correct all_sessions;
+  norm_spec [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate) all_sessions)
+
+val protocol_invariants_p_has_p_session_invariant: squash (has_local_state_predicate state_predicate_p)
+let protocol_invariants_p_has_p_session_invariant = all_sessions_has_all_sessions ()
+
+val protocol_invariants_p_has_pki_invariant: squash (has_pki_invariant #protocol_invariants_p)
+let protocol_invariants_p_has_pki_invariant = all_sessions_has_all_sessions ()
+
+val protocol_invariants_p_has_private_keys_invariant: squash (has_private_keys_invariant #protocol_invariants_p)
+let protocol_invariants_p_has_private_keys_invariant = all_sessions_has_all_sessions ()
+
+val all_events_has_all_events: unit -> Lemma (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred #protocol_invariants_p) all_events))
+let all_events_has_all_events () =
+  assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_events)));
+  mk_event_pred_correct #protocol_invariants_p all_events;
+  norm_spec [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred #protocol_invariants_p) all_events);
+  let dumb_lemma (x:prop) (y:prop): Lemma (requires x /\ x == y) (ensures y) = () in
+  dumb_lemma (for_allP (has_compiled_event_pred #protocol_invariants_p) all_events) (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred #protocol_invariants_p) all_events))
+
+// As an example, below `#protocol_invariants_nsl` is omitted and instantiated using F*'s typeclass resolution algorithm
+val protocol_invariants_nsl_has_nsl_event_invariant: squash (has_event_pred event_predicate_event_t)
+let protocol_invariants_nsl_has_nsl_event_invariant = all_events_has_all_events ()

--- a/examples/Online_with_authn/DY.OnlineA.Invariants.fst
+++ b/examples/Online_with_authn/DY.OnlineA.Invariants.fst
@@ -24,68 +24,57 @@ open DY.OnlineA.Protocol
 /// With this, we then know that
 /// the protocol model satisfies the secrecy property.
 
+/// We highlight only the differences to
+/// the invariants for the nonce secrecy proof (Online_with_secrecy/DY.OnlineS.Invariants.fst)
+/// 
 
 (*** Crypto Invariants ***)
 
 
-(** TODO **)
-// needed for `crypto_prediates.pke_pred.pred_later`
 %splice [ps_ping_t_is_well_formed] (gen_is_well_formed_lemma (`ping_t))
 %splice [ps_ack_t_is_well_formed] (gen_is_well_formed_lemma (`ack_t))
 %splice [ps_message_t_is_well_formed] (gen_is_well_formed_lemma (`message_t))
 
-
-
-// ignore this for now
 instance crypto_usages_p : crypto_usages = default_crypto_usages
 
 #push-options "--ifuel 2"
 let crypto_p : crypto_predicates = { 
   default_crypto_predicates with 
-  (* we restrict when a message is allowed to be encrypted 
-     with some secret key
-
-     Or put differently:
-     What are the guarantees that an honest sender can provide
-     that are available at the receiver after decryption?
-  *)
   pke_pred = { 
     pred = (fun tr sk_usage msg ->
-    exists prin. // the intended receiver of the message
+    exists prin.
     (
-      // needed for `decode_ping_proof` [Why?]
-      (* the key used for the encryption is
-         a protocol-level public key for the intended receiver (prin) 
-      *)
       sk_usage == long_term_key_type_to_usage (LongTermPkeKey key_tag) prin /\
       (match parse message_t msg with
       | Some (Ping ping) ->
-          (* a Ping message can only be encrypted if
-             (Or: if you decrypt a Ping from an honest party 
-             you get the guarantees that:)
-             the contained nonce n_a
-             is labeled for 
-             * the name provided in the message (alice)
-             * and the intended receiver of the message (bob)
-          *)
           let bob = prin in
           let alice = ping.alice in
           let n_a = ping.n_a in
           get_label tr n_a == nonce_label alice bob
+          (* additionally, we here also require/guarantee
+             that the principal in the message (alice)
+             stored a SendingPing state before sendind the message,
+             containing:
+             * the intended receiver (bob) and
+             * the nonce in the message (n_a)
+          *)
           /\ state_was_set_some_id tr alice (SendingPing {bob; n_a})
       | Some (Ack ack) ->
           let alice = prin in
           let n_a = ack.n_a in
+          (* In contrast to the secrecy proof,
+             where we didn't need any guarantees for an Ack message,
+             we here have the property that
+             there is some principal bob that 
+             stored a SendingAck state with 
+             * the intended receiver of the Ack (alice) and
+             * the nonce in the Ack (n_a)
+          *)
           exists bob.
-          state_was_set_some_id tr bob (SendingAck {alice = prin; n_a = ack.n_a})
-          /\ get_label tr n_a `can_flow tr` principal_label bob
-      | _ -> False // other messages can not be encrypted
+            state_was_set_some_id tr bob (SendingAck {alice = prin; n_a = ack.n_a})
+      | _ -> False
       ))
       ); 
-    (* a lemma guaranteeing:
-       if the predicate specified above holds for some trace tr1
-       it also holds for any extension tr2 of tr1
-    *)
     pred_later = (fun tr1 tr2 pk msg -> 
       parse_wf_lemma message_t (bytes_well_formed tr1) msg
     ) 
@@ -103,46 +92,45 @@ instance crypto_invariants_p: crypto_invariants = {
 
 (*** State Invariant ***)
 
-// TODO
-// Needed for `state_predicate.pred_knowable`
 %splice [ps_sent_ping_t_is_well_formed] (gen_is_well_formed_lemma (`sent_ping_t))
 %splice [ps_sent_ack_t_is_well_formed] (gen_is_well_formed_lemma (`sent_ack_t))
 %splice [ps_received_ack_t_is_well_formed] (gen_is_well_formed_lemma (`received_ack_t))
 %splice [ps_state_t_is_well_formed] (gen_is_well_formed_lemma (`state_t))
 
-#push-options "--z3cliopt 'smt.qi.eager_threshold=50'"
-(* We restrict what states are allowed to be stored by principals *)
+#push-options "--ifuel 2 --z3cliopt 'smt.qi.eager_threshold=50'"
 let state_predicate_p: local_state_predicate state_t = {
   pred = (fun tr prin sess_id st ->
     match st with
     | SendingPing ping -> (
-        (* a SendingPing state may only be stored if
-           the stored nonce is labeled for
-           * the storing principal (alice)
-           * the principal stored in the state 
-             (the intended receiver of the Ping: bob)
-        *) 
         let alice = prin in
         let bob = ping.bob in
         let n_a = ping.n_a in
         is_secret (nonce_label alice bob) tr n_a
+        (* additionally to the secrecy proof,
+           we add the property that 
+           the storing principal (alice)
+           triggered in Initiating event containing:
+           * her own name
+           * the principal stored in the state (bob) and
+           * the nonce stored in the state (n_a)
+        *) 
         /\ event_triggered tr alice (Initiating {alice = alice; bob = bob; n_a = n_a})
     )
     | SendingAck ack -> (
-        (* a SendingAck state may only be stored if
-           the stored nonce is readable by
-           the storing principal (bob)
-
-           -- this is a condition that must always hold,
-           and is enforced by the `pred_knowable` Lemma.
-        *)
         let bob = prin in
         let n_a = ack.n_a in
         is_knowable_by (principal_label bob) tr n_a
-        /\ (exists alice.
-          //is_corrupt tr (principal_label alice) \/
+        (* here we add,
+           that the stored other principal (alice)
+           stored a SendingPing state containing
+           * the current storing principal (bob) and
+           * the nonce stored in the state (n_a)
+           except, if we are in the case that 
+           the stored nonce (n_a) has leaked to the attacker.
+        *)
+        /\ (
           is_publishable tr n_a \/
-          event_triggered tr alice (Initiating {alice; bob; n_a})
+          state_was_set_some_id tr ack.alice (SendingPing {bob; n_a})
         )
     )
     | ReceivedAck rack  -> (
@@ -155,38 +143,49 @@ let state_predicate_p: local_state_predicate state_t = {
         let alice = prin in
         let bob = rack.bob in
         let n_a = rack.n_a in
-        is_knowable_by (principal_label alice) tr n_a /\
+        is_secret (nonce_label alice bob) tr n_a /\
 
+        (* this is already the authentication property we want to show:
+           alice stores a ReceivedAck state only, if
+           the stored principal (bob) stored a SendingAck state containing:
+           * alice and
+           * the nonce n_a
+           unless,
+           one of alice or bob are corrupt
+        *)
         (state_was_set_some_id tr bob (SendingAck {alice; n_a})
         \/ (is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob)))
     )
   );
-  (* as for encryption we have a lemma guaranteeing:
-     if the state predicate holds on some trace tr1
-     it also holds for any extension tr2 of tr2
-  *)
   pred_later = (fun tr1 tr2 prin sess_id st -> () );
-  (* a lemma guaranteeing that
-     the content of the state to be stored
-     is readable by the storing principal
-  *)
-  pred_knowable = (fun tr prin sess_id st -> 
-    match st with
-    | SendingAck ack -> ()
-    | _ -> ()
-  );
+  pred_knowable = (fun tr prin sess_id st -> () );
 }
 #pop-options
 
 (*** Event Pred ***)
 
+/// As for messages and states,
+/// we also have prediates on events.
+/// The intuition is similar:
+/// They say when an event is allowed to be triggered, or
+/// what guarantees we obtain, if we observe an event on the trace.
+
 let event_predicate_event_t: event_predicate event_t =
   fun tr prin e ->
+  // prin is the principal triggering the event
     match e with    
     | Initiating init -> (
         let alice = init.alice in
         let bob = init.bob in
         let n_a = init.n_a in
+        (* We may trigger the Initiating event only if,
+           * the triggering principal is the first principal stored in the event (alice)
+           * the nonce (n_a) in the event is labelled for 
+             the two principals stored in the event (alice and bob)
+           * the stored nonce (n_a) was generated right before the event is triggered
+             (this is crucial and will be used to show an injectivity property,
+             that there will be only one such event for a fixed nonce n_a)
+        *)
         prin == alice /\
         is_secret (nonce_label alice bob) tr n_a /\
         0 < DY.Core.Trace.Base.length tr /\
@@ -195,15 +194,13 @@ let event_predicate_event_t: event_predicate event_t =
 
 (*** Trace invariants ***)
 
-// TODO: can this (all_sessions and all_events) be hidden somehow?
 let all_sessions = [
   pki_tag_and_invariant;
   private_keys_tag_and_invariant;
   (|local_state_state.tag, local_state_predicate_to_local_bytes_state_predicate state_predicate_p|);
 ]
 
-/// We have no events here,
-/// but we need to specify that for the trace invariants
+/// Now we have an event type
 let all_events = [(event_event_t.tag, compile_event_pred event_predicate_event_t)]
 
 
@@ -231,9 +228,7 @@ instance protocol_invariants_p: protocol_invariants = {
 }
 
 
-(*** Helper Lemmas for the Secrecy Proof ***)
-
-// TODO: Can all of this be hidden somehow?
+(*** Helper Lemmas ***)
 
 val all_sessions_has_all_sessions: unit -> Lemma (norm [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate) all_sessions))
 let all_sessions_has_all_sessions () =
@@ -250,6 +245,8 @@ let protocol_invariants_p_has_pki_invariant = all_sessions_has_all_sessions ()
 val protocol_invariants_p_has_private_keys_invariant: squash (has_private_keys_invariant #protocol_invariants_p)
 let protocol_invariants_p_has_private_keys_invariant = all_sessions_has_all_sessions ()
 
+/// We need similar lemmas for our event type
+
 val all_events_has_all_events: unit -> Lemma (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred #protocol_invariants_p) all_events))
 let all_events_has_all_events () =
   assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_events)));
@@ -258,6 +255,5 @@ let all_events_has_all_events () =
   let dumb_lemma (x:prop) (y:prop): Lemma (requires x /\ x == y) (ensures y) = () in
   dumb_lemma (for_allP (has_compiled_event_pred #protocol_invariants_p) all_events) (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred #protocol_invariants_p) all_events))
 
-// As an example, below `#protocol_invariants_nsl` is omitted and instantiated using F*'s typeclass resolution algorithm
-val protocol_invariants_nsl_has_nsl_event_invariant: squash (has_event_pred event_predicate_event_t)
-let protocol_invariants_nsl_has_nsl_event_invariant = all_events_has_all_events ()
+val protocol_invariants_p_has_event_t_invariant: squash (has_event_pred event_predicate_event_t)
+let protocol_invariants_p_has_event_t_invariant = all_events_has_all_events ()

--- a/examples/Online_with_authn/DY.OnlineA.Invariants.fst
+++ b/examples/Online_with_authn/DY.OnlineA.Invariants.fst
@@ -19,14 +19,13 @@ open DY.OnlineA.Protocol
 ///   * event invariants
 ///
 /// We then have to show
-/// * these invariants imply the secrecy property (see DY.OnlineS.Secrecy) and
+/// * these invariants imply the security properties: responder authentication and nonce secrecy (see DY.OnlineS.Properties) and
 /// * every protocol step maintains these invariants (see DY.OnlineS.Invariants.Proofs)
 /// With this, we then know that
-/// the protocol model satisfies the secrecy property.
+/// the protocol model satisfies the security properties.
 
 /// We highlight only the differences to
 /// the invariants for the nonce secrecy proof (Online_with_secrecy/DY.OnlineS.Invariants.fst)
-/// 
 
 (*** Crypto Invariants ***)
 
@@ -134,12 +133,6 @@ let state_predicate_p: local_state_predicate state_t = {
         )
     )
     | ReceivedAck rack  -> (
-        (* a ReceivedAck state may only be stored if
-           the stored nonce is labeled for
-           * the storing principal (alice)
-           * the principal stored in the state
-             (the expected sender of the Ack)
-        *)
         let alice = prin in
         let bob = rack.bob in
         let n_a = rack.n_a in
@@ -168,7 +161,7 @@ let state_predicate_p: local_state_predicate state_t = {
 /// we also have prediates on events.
 /// The intuition is similar:
 /// They say when an event is allowed to be triggered, or
-/// what guarantees we obtain, if we observe an event on the trace.
+/// what guarantees we obtain, if we observe a specific event on the trace.
 
 let event_predicate_event_t: event_predicate event_t =
   fun tr prin e ->
@@ -215,11 +208,6 @@ let trace_invariants_p: trace_invariants = {
 
 
 (*** Protocol Invariants ***)
-
-/// The final protocol invariants
-/// consisting of
-/// * the crypto invariants and
-/// * the trace invariants
 
 instance protocol_invariants_p: protocol_invariants = {
   crypto_invs = crypto_invariants_p;

--- a/examples/Online_with_authn/DY.OnlineA.Invariants.fst
+++ b/examples/Online_with_authn/DY.OnlineA.Invariants.fst
@@ -188,8 +188,7 @@ let event_predicate_event_t: event_predicate event_t =
         *)
         prin == alice /\
         is_secret (nonce_label alice bob) tr n_a /\
-        0 < DY.Core.Trace.Base.length tr /\
-        rand_generated_at tr (DY.Core.Trace.Base.length tr - 1) n_a
+        rand_just_generated tr n_a
     )
 
 (*** Trace invariants ***)

--- a/examples/Online_with_authn/DY.OnlineA.Properties.fst
+++ b/examples/Online_with_authn/DY.OnlineA.Properties.fst
@@ -28,7 +28,7 @@ val responder_authentication:
      is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob) \/
      state_was_set_some_id tr bob (SendingAck {alice; n_a})
   )
-let authn tr alice bob n_a = ()
+let responder_authentication tr alice bob n_a = ()
 
 
 /// We still have nonce secrecy:

--- a/examples/Online_with_authn/DY.OnlineA.Properties.fst
+++ b/examples/Online_with_authn/DY.OnlineA.Properties.fst
@@ -1,4 +1,4 @@
-module DY.OnlineA.Authn
+module DY.OnlineA.Properties
 
 open Comparse
 open DY.Core
@@ -15,7 +15,7 @@ open DY.OnlineA.Invariants
 /// i.e., Bob sent n_a in an acknowledgement to Alice.
 /// Unless one of Alice or Bob are corrupt.
 
-val authn:
+val responder_authentication:
   tr:trace -> 
   alice:principal -> bob:principal ->
   n_a:bytes ->

--- a/examples/Online_with_authn/DY.OnlineA.Protocol.fst
+++ b/examples/Online_with_authn/DY.OnlineA.Protocol.fst
@@ -1,0 +1,172 @@
+module DY.OnlineA.Protocol
+
+open Comparse
+open DY.Core
+open DY.Lib
+
+open DY.Simplified
+open DY.Extend
+
+open DY.OnlineA.Data
+
+/// Here we define the DY* mode of the "Online?" protocol,
+/// an extension of the simple Two Message protocol:
+/// the two messages are now (asymmetrically) encrypted
+///
+/// A -> B: enc{Ping (A, n_A)}_B
+/// B -> A: enc{Ack n_A}_A
+///
+/// The model consists of 3 functions,
+/// one for each protocol step
+/// (just as for the simple two message protocol):
+/// 1. Alice sends the Ping to Bob (`send_ping`)
+/// 2. Bob receives the Ping and replies with the Ack (`receive_ping_and_send_ack`)
+/// 3. Alice receives the Ack (`receive_ack`)
+///
+/// Additionally, there are two helper functions
+/// for steps 2 and 3 (`decode_ping` and `decode_ack`).
+
+(*** Sending the Ping ***)
+
+/// Alice sends the first message to Bob:
+/// * Alice generates a new nonce [n_a]
+/// * encrypts the message (Alice, n_a) for Bob
+/// * sends the encrypted message
+/// * stores n_a and Bob in a state (in a new session)
+/// The step returns the ID of the new state
+/// and the timestamp of the message on the trace
+/// The step fails, if
+/// encryption was not successful, i.e.,
+/// Alice does not have a public key of Bob.
+
+let nonce_label alice bob = join (principal_label alice) (principal_label bob)
+
+val send_ping: principal -> principal -> state_id -> traceful (option (state_id & timestamp))
+let send_ping alice bob keys_sid =
+  let* n_a = gen_rand_labeled (nonce_label alice bob) in
+
+  trigger_event alice (Initiating {alice = alice; bob = bob; n_a = n_a});*
+
+  let ping = Ping {alice; n_a} in 
+
+  let ping_state = SendingPing {bob; n_a} in
+  let* sid = start_new_session alice ping_state in
+
+  // encrypt the message for bob
+  let*? ping_encrypted = pke_enc_for alice bob keys_sid key_tag ping in
+  let* msg_ts = send_msg ping_encrypted in
+ 
+  return (Some (sid, msg_ts))
+
+
+(*** Replying to a Ping with an Ack ***)
+
+
+/// Bob receives the first messages and replies:
+/// * read the message from the trace
+/// * decrypt the message to (Alice, n_a)
+/// * encrypt the reply (n_a) for Alice
+/// * send the encrypted reply
+/// * store n_a and Alice in a state in a new session
+/// The step returns the ID of the new state
+/// and the timestamp of the reply on the trace.
+/// The step fails, if one of
+/// * decryption fails
+/// * the message is not of the right type, i.e., not a first message
+/// * encryption fails
+
+/// Decrypting the message (Step 2 from above) is pulled out to a separate function
+/// The function
+/// * decrypts the message
+/// * checks that the message is of the right type (a Ping)
+/// * returns the content of the message
+/// The function fails if decryption fails.
+
+val decode_ping : principal -> state_id -> bytes -> traceful (option ping_t)
+let decode_ping bob keys_sid msg =
+  // try to decrypt the message with
+  // a private key of bob with the protocol tag
+  // (fails, if no such key exists)
+  let*? png = pke_dec_with_key_lookup #message_t bob keys_sid key_tag msg in
+  
+  // check that the decrypted message is of the right type
+  // (otherwise fail)
+  guard_tr (Ping? png);*?
+
+  // return the content of the message 
+  // (i.e., strip the Ping constructor)
+  return (Some (Ping?.ping png))
+
+/// Now the actual receive and reply step
+/// using the decode function
+val receive_ping_and_send_ack: principal -> global_sess_ids -> timestamp -> traceful (option (state_id & timestamp))
+let receive_ping_and_send_ack bob global_sids msg_ts =
+  let*? msg = recv_msg msg_ts in
+  // decode the received expected ping
+  let*? png = decode_ping bob global_sids.private_keys msg in
+
+  let n_a = png.n_a in
+  let alice = png.alice in
+
+  let ack = Ack {n_a} in
+
+  let* sess_id = start_new_session bob (SendingAck {alice; n_a}) in
+  
+  // encrypt the reply for alice
+  let*? ack_encrypted = pke_enc_for bob alice global_sids.pki key_tag ack in
+  let* ack_ts = send_msg ack_encrypted in
+  
+  return (Some (sess_id, ack_ts))
+
+
+(*** Receiving an Ack ***)
+
+
+/// Alice receives the reply from Bob:
+/// * read the message from the trace
+/// * decrypt the message to (n_a)
+/// * check if Alice previously sent n_a in some session
+/// * store completion of this session in a new state
+/// Returns the ID of the session that is marked as completed.
+/// The step fails, if one of
+/// * decryption fails
+/// * the message is not of the right type, i.e., not a reply
+/// * there is no prior session related to n_a
+
+
+/// Again, we pull out decryption of the message (Step 2):
+/// * decrypt the message
+/// * check that the message is of the Ack type
+/// Returns the content of the reply.
+/// Fails if decryption fails.
+
+val decode_ack : principal -> state_id -> bytes -> traceful (option ack_t)
+let decode_ack alice keys_sid cipher =
+  // try to decrypt the message with
+  // a private key of alice with the protocol tag
+  let*? ack = pke_dec_with_key_lookup #message_t alice keys_sid key_tag cipher in
+
+  // check that the decrypted message is of the Ack type
+  guard_tr (Ack? ack);*?
+
+  // return the content of the message
+  return (Some (Ack?.ack ack))
+
+/// The actual protocol step using the decode function
+val receive_ack: principal -> state_id -> timestamp -> traceful (option state_id)
+let receive_ack alice keys_sid ack_ts =
+  let*? msg = recv_msg ack_ts in
+  // decode the received expected ack
+  let*? ack = decode_ack alice keys_sid msg in
+
+  let n_a = ack.n_a in
+
+  let*? (st, sid) = lookup_state #state_t alice
+    (fun st -> SendingPing? st && (SendingPing?.ping st).n_a = n_a)
+    in
+  guard_tr(SendingPing? st);*?
+  let bob = (SendingPing?.ping st).bob in
+
+  set_state alice sid (ReceivedAck {bob; n_a});*
+
+  return (Some sid)

--- a/examples/Online_with_authn/DY.OnlineA.Run.Printing.fst
+++ b/examples/Online_with_authn/DY.OnlineA.Run.Printing.fst
@@ -26,11 +26,17 @@ let state_to_string b =
   | ReceivedAck r -> Some (Printf.sprintf "ReceivedAck [n_a = (%s), from = (%s)]" (bytes_to_string r.n_a) r.bob)
 
 
-
+val event_to_string: bytes -> option string
+let event_to_string event_bytes =
+  let? event = parse event_t event_bytes in
+  match event with
+ | Initiating {alice; bob; n_a} -> (
+    Some (Printf.sprintf "Initiating [alice=%s, with=(%s), using n_b=(%s)]" alice bob (bytes_to_string n_a))
+  )
 
 val get_trace_to_string_printers: trace_to_string_printers
 let get_trace_to_string_printers  = 
   trace_to_string_printers_builder 
     message_to_string
     [(local_state_state.tag, state_to_string)]
-    []
+    [(event_event_t.tag, event_to_string)]

--- a/examples/Online_with_authn/DY.OnlineA.Run.Printing.fst
+++ b/examples/Online_with_authn/DY.OnlineA.Run.Printing.fst
@@ -1,0 +1,36 @@
+module DY.OnlineA.Run.Printing
+
+open DY.Core
+open DY.Lib
+open Comparse
+
+open DY.OnlineA.Data
+
+/// Helper functions for trace printing.
+/// Here we define how our abstract message and state types
+/// should be printed.
+
+
+val message_to_string: bytes -> option string
+let message_to_string b =
+  match? parse message_t b with
+  | Ping p -> Some (Printf.sprintf "Ping [name = (%s), n_a = (%s)]" (p.alice) (bytes_to_string p.n_a))
+  | Ack a -> Some (Printf.sprintf "Ping [n_a = (%s)]" (bytes_to_string a.n_a))
+
+
+val state_to_string: bytes -> option string
+let state_to_string b =
+  match? parse state_t b with
+  | SendingPing p -> Some (Printf.sprintf "SendingPing [n_a = (%s), to = (%s)]" (bytes_to_string p.n_a) p.bob)
+  | SendingAck a -> Some (Printf.sprintf "SendingAck [n_a = (%s), to = (%s)]" (bytes_to_string a.n_a) a.alice)
+  | ReceivedAck r -> Some (Printf.sprintf "ReceivedAck [n_a = (%s), from = (%s)]" (bytes_to_string r.n_a) r.bob)
+
+
+
+
+val get_trace_to_string_printers: trace_to_string_printers
+let get_trace_to_string_printers  = 
+  trace_to_string_printers_builder 
+    message_to_string
+    [(local_state_state.tag, state_to_string)]
+    []

--- a/examples/Online_with_authn/DY.OnlineA.Run.fst
+++ b/examples/Online_with_authn/DY.OnlineA.Run.fst
@@ -80,4 +80,4 @@ let run () : traceful (option unit ) =
 
   return (Some ())
 
-let _ = run () Nil
+let _ = run () empty_trace

--- a/examples/Online_with_authn/DY.OnlineA.Run.fst
+++ b/examples/Online_with_authn/DY.OnlineA.Run.fst
@@ -1,0 +1,83 @@
+module DY.OnlineA.Run
+
+open DY.Core
+open DY.Lib
+
+open DY.OnlineA.Run.Printing
+open DY.OnlineA.Data
+open DY.OnlineA.Protocol
+
+/// Here, we print the trace after a successful run of the Two Message protocol.
+
+
+let run () : traceful (option unit ) =
+  let _ = IO.debug_print_string "************* Trace *************\n" in
+
+  (*** Protocol Setup ***)
+
+  // the names of the participants
+  let alice = "Alice" in
+  let bob = "Bob" in
+
+  (*** PKI setup ***)
+
+  // Initialize key storage for Alice
+  // private and public keys are stored in separate sessions
+  let* alice_priv_keys_sid = initialize_private_keys alice in
+  let* alice_pub_keys_sid = initialize_pki alice in
+  // we collect both session ids in a global record
+  let alice_global_session_ids : global_sess_ids = 
+    { pki = alice_pub_keys_sid; 
+      private_keys = alice_priv_keys_sid
+    } in
+
+  // Initialize key storage for Bob
+  let* bob_priv_keys_sid = initialize_private_keys bob in
+  let* bob_pub_keys_sid = initialize_pki bob in  
+  let bob_global_session_ids: global_sess_ids = 
+    { pki = bob_pub_keys_sid; 
+      private_keys = bob_priv_keys_sid
+    } in
+
+  // Generate private key for Alice and store it in her private keys session
+  generate_private_key alice alice_global_session_ids.private_keys (LongTermPkeKey key_tag);*
+  
+  // Generate private key for Bob and store it in his private keys session
+  generate_private_key bob bob_global_session_ids.private_keys (LongTermPkeKey key_tag);*
+
+  // Store Bob's public key in Alice's state
+  // Bob's public key is computed from his private key
+  // 1. Retrieve Bob's private key from his private key session
+  // 2. Compute the public key from the private key
+  // 3. Install Bob's public key in Alice's public key store
+  let*? priv_key_bob = get_private_key bob bob_global_session_ids.private_keys (LongTermPkeKey key_tag) in
+  let pub_key_bob = pk priv_key_bob in
+  install_public_key alice alice_global_session_ids.pki (LongTermPkeKey key_tag) bob pub_key_bob;*
+
+  // Store Alice's public key in Bob's state in the same way
+  let*? priv_key_alice = get_private_key alice alice_global_session_ids.private_keys (LongTermPkeKey key_tag) in
+  let pub_key_alice = pk priv_key_alice in
+  install_public_key bob bob_global_session_ids.pki (LongTermPkeKey key_tag) alice pub_key_alice;*
+
+
+
+  (*** The actual protocol run ***)
+
+  // Alice sends a Ping to Bob
+  let*? (alice_sid, ping_ts) = send_ping alice bob alice_global_session_ids.pki in
+  // Bob replies with an Ack (reading the ping at the given timestamp)
+  let*? (bob_sid, ack_ts) = receive_ping_and_send_ack bob bob_global_session_ids ping_ts in
+  // Alice receives the Ack (at the given ack timestamp)
+  let*? _ = receive_ack alice alice_global_session_ids.private_keys ack_ts in
+
+
+ (*** Printing the Trace ***)
+
+  let* tr = get_trace in
+  let _ = IO.debug_print_string (
+      trace_to_string get_trace_to_string_printers tr
+    ) in
+
+  return (Some ())
+
+let _ = run () Nil

--- a/examples/Online_with_authn/Makefile
+++ b/examples/Online_with_authn/Makefile
@@ -1,0 +1,10 @@
+TUTORIAL_HOME ?= ../..
+
+EXAMPLES = Online_with_authn
+EXAMPLE_DIRS = $(addprefix $(TUTORIAL_HOME)/examples/, $(EXAMPLES))
+
+include $(TUTORIAL_HOME)/Makefile
+
+test:
+	cd $(TUTORIAL_HOME)/obj; OCAMLPATH=$(FSTAR_HOME)/lib:$(OCAMLPATH) ocamlbuild -use-ocamlfind -pkg batteries -pkg fstar.lib DY_OnlineA_Run.native
+	$(TUTORIAL_HOME)/obj/DY_OnlineA_Run.native

--- a/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.Protocol.Total.Proof.fst
+++ b/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.Protocol.Total.Proof.fst
@@ -17,24 +17,6 @@ open DY.Example.NSL.Protocol.Stateful
 
 (*** Cryptographic invariants ***)
 
-let state_was_set_some_id (#a:Type) {|local_state a|} tr prin (cont : a) =
-  exists sid. state_was_set tr prin sid cont
-
-val state_was_set_some_id_grows:
-  #a:Type -> {|lsa:local_state a|} ->
-  tr1:trace -> tr2:trace -> 
-  prin:principal -> content:a ->
-  Lemma
-  (requires tr1 <$ tr2
-    /\ state_was_set_some_id tr1 prin content
-  )
-  (ensures
-    state_was_set_some_id tr2 prin content
-  )
-  [SMTPat (state_was_set_some_id #a #lsa tr1 prin content); SMTPat (tr1 <$ tr2)]
-let state_was_set_some_id_grows #a #ls tr1 tr2 prin content  = admit()
-
-
 instance crypto_usages_nsl : crypto_usages = default_crypto_usages
 
 #push-options "--ifuel 2 --fuel 0"
@@ -80,17 +62,6 @@ instance crypto_invariants_nsl : crypto_invariants = {
 }
 
 (*** Proofs ***)
-
-let is_secret_is_knowable l tr b:
-  Lemma 
-  (requires is_secret l tr b)
-  (ensures is_knowable_by l tr b)
-  [SMTPat (is_secret l tr b)]
-  = ()
-
-let rand_generated_before tr b = 
-  exists ts. rand_generated_at tr ts b
-
 
 val compute_message1_proof:
   tr:trace ->

--- a/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.SecurityProperties.fst
+++ b/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.SecurityProperties.fst
@@ -3,6 +3,9 @@ module DY.Example.NSL.SecurityProperties
 open Comparse
 open DY.Core
 open DY.Lib
+
+open DY.Extend
+
 open DY.Example.NSL.Protocol.Total.Proof
 open DY.Example.NSL.Protocol.Stateful
 open DY.Example.NSL.Protocol.Stateful.Proof


### PR DESCRIPTION
Added responder authentication property to the Online Protocol.
This can be used as a first example for introducing events. (It is very similar to the NSL example with only one event)

For events, we need the order
1. storing the new state
2. sending the message

That is the opposite order of what we previously had for the secrecy property of the Online protocol (compare to https://github.com/REPROSEC/dolev-yao-star-tutorial-code/blob/e17508022e2447d0a665b305c48d97462d2b4eed/examples/Online_with_secrecy/DY.OnlineS.Protocol.fst#L44-L58

Maybe we should swap this order already in the Online secrecy model (and the Two-Message protocol model)?