### PR TITLE
Using `prefix` in AuthN properties

### DIFF
--- a/dy-extensions/DY.Extend.fst
+++ b/dy-extensions/DY.Extend.fst
@@ -95,6 +95,17 @@ val state_was_set_at:
 let state_was_set_at #a #ls tr ts prin sid cont =
   state_was_set_at_tagged tr ts ls.tag prin sid (serialize a cont)
 
+val state_was_set_at_some_id:
+  #a:Type -> {|local_state a|} ->
+  (tr:trace) -> (ts: timestamp) -> 
+  (prin: principal) ->
+  (cont:a) ->
+  prop
+let state_was_set_at_some_id #a #ls tr ts prin cont =
+  exists sid. state_was_set_at tr ts prin sid cont
+
+
+
 val entry_at_invariant:
   {|protocol_invariants|} ->
   tr:trace -> ts:timestamp -> 

--- a/examples/Online_with_authn/DY.OnlineA.Properties.fst
+++ b/examples/Online_with_authn/DY.OnlineA.Properties.fst
@@ -9,6 +9,8 @@ open DY.Extend
 open DY.OnlineA.Data
 open DY.OnlineA.Invariants
 
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 25  --z3cliopt 'smt.qi.eager_threshold=100'"
+
 /// This is the new property, we want to show:
 /// if Alice finishes a run identified by Bob and a nonce n_a,
 /// then this Bob was involved in the run,
@@ -17,19 +19,21 @@ open DY.OnlineA.Invariants
 
 val responder_authentication:
   tr:trace -> 
-  alice:principal -> bob:principal ->
+  ts:timestamp ->
+  alice:principal -> sid:state_id 
+  -> bob:principal ->
   n_a:bytes ->
   Lemma
   (requires
      trace_invariant tr /\
-     state_was_set_some_id tr alice (ReceivedAck {bob; n_a})
+     // state_was_set_some_id tr alice (ReceivedAck {bob; n_a})
+     state_was_set_at tr ts alice sid (ReceivedAck {bob; n_a})
   )
   (ensures
-     is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob) \/
-     state_was_set_some_id tr bob (SendingAck {alice; n_a})
+     is_corrupt (prefix tr ts) (principal_label alice) \/ is_corrupt (prefix tr ts) (principal_label bob) \/
+     state_was_set_some_id (prefix tr ts) bob (SendingAck {alice; n_a})
   )
-let responder_authentication tr alice bob n_a = ()
-
+let responder_authentication tr ts alice sid bob n_a = ()
 
 /// We still have nonce secrecy:
 

--- a/examples/Online_with_authn/DY.OnlineA.Properties.fst
+++ b/examples/Online_with_authn/DY.OnlineA.Properties.fst
@@ -14,26 +14,26 @@ open DY.OnlineA.Invariants
 /// This is the new property, we want to show:
 /// if Alice finishes a run identified by Bob and a nonce n_a,
 /// then this Bob was involved in the run,
-/// i.e., Bob sent n_a in an acknowledgement to Alice.
+/// i.e., Bob previously sent n_a in an acknowledgement to Alice.
 /// Unless one of Alice or Bob are corrupt.
 
 val responder_authentication:
   tr:trace -> 
   ts:timestamp ->
-  alice:principal -> sid:state_id 
-  -> bob:principal ->
+  alice:principal ->
+  bob:principal ->
   n_a:bytes ->
   Lemma
   (requires
      trace_invariant tr /\
-     // state_was_set_some_id tr alice (ReceivedAck {bob; n_a})
-     state_was_set_at tr ts alice sid (ReceivedAck {bob; n_a})
+     state_was_set_at_some_id tr ts alice (ReceivedAck {bob; n_a})
   )
   (ensures
-     is_corrupt (prefix tr ts) (principal_label alice) \/ is_corrupt (prefix tr ts) (principal_label bob) \/
+     is_corrupt tr (principal_label alice) \/ 
+     is_corrupt tr (principal_label bob) \/
      state_was_set_some_id (prefix tr ts) bob (SendingAck {alice; n_a})
   )
-let responder_authentication tr ts alice sid bob n_a = ()
+let responder_authentication tr ts alice bob n_a = ()
 
 /// We still have nonce secrecy:
 

--- a/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.SecurityProperties.fst
+++ b/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.SecurityProperties.fst
@@ -26,19 +26,18 @@ open DY.Example.NSL.Protocol.Stateful.Proof
 
 val initiator_authentication:
   tr:trace -> ts:timestamp ->
-  alice:principal -> 
-  bob:principal -> sid:state_id ->
+  alice:principal -> bob:principal ->
   n_a:bytes -> n_b:bytes ->
   Lemma
   (requires
-    state_was_set_at tr ts bob sid (ResponderReceivedMsg3 alice n_a n_b) /\
+    state_was_set_at_some_id tr ts bob (ResponderReceivedMsg3 alice n_a n_b) /\
     trace_invariant tr
   )
   (ensures
     is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob) \/
   state_was_set_some_id (prefix tr ts) alice (InitiatorSendingMsg1 bob n_a)
   )
-let initiator_authentication tr ts alice bob sid n_a n_b = ()
+let initiator_authentication tr ts alice bob n_a n_b = ()
   
 /// If Alice thinks she talks with Bob,
 /// then Bob thinks he talk to Alice (with the same nonces),
@@ -46,18 +45,18 @@ let initiator_authentication tr ts alice bob sid n_a n_b = ()
 
 val responder_authentication:
   tr:trace -> ts:timestamp ->
-  alice:principal -> sid:state_id ->
-  bob:principal -> n_a:bytes -> n_b:bytes ->
+  alice:principal -> bob:principal -> 
+  n_a:bytes -> n_b:bytes ->
   Lemma
   (requires
-    state_was_set_at tr ts alice sid (InitiatorSendingMsg3 bob n_a n_b) /\
+    state_was_set_at_some_id tr ts alice (InitiatorSendingMsg3 bob n_a n_b) /\
     trace_invariant tr
   )
   (ensures
     is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob) \/
     state_was_set_some_id (prefix tr ts) bob (ResponderSendingMsg2 alice n_a n_b)
   )
-let responder_authentication tr i alice sid bob n_a n_b = ()
+let responder_authentication tr i alice bob n_a n_b = ()
 
 /// The nonce n_a is unknown to the attacker,
 /// unless the attacker corrupted Alice or Bob.

--- a/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.SecurityProperties.fst
+++ b/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.SecurityProperties.fst
@@ -25,36 +25,39 @@ open DY.Example.NSL.Protocol.Stateful.Proof
 /// unless the attacker corrupted Alice or Bob.
 
 val initiator_authentication:
-  tr:trace -> i:timestamp ->
-  alice:principal -> bob:principal -> n_a:bytes -> n_b:bytes ->
+  tr:trace -> ts:timestamp ->
+  alice:principal -> 
+  bob:principal -> sid:state_id ->
+  n_a:bytes -> n_b:bytes ->
   Lemma
   (requires
-    state_was_set_some_id tr bob (ResponderReceivedMsg3 alice n_a n_b) /\
+    state_was_set_at tr ts bob sid (ResponderReceivedMsg3 alice n_a n_b) /\
     trace_invariant tr
   )
   (ensures
     is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob) \/
-  state_was_set_some_id tr alice (InitiatorSendingMsg1 bob n_a)
+  state_was_set_some_id (prefix tr ts) alice (InitiatorSendingMsg1 bob n_a)
   )
-let initiator_authentication tr i alice bob n_a n_b = ()
-
+let initiator_authentication tr ts alice bob sid n_a n_b = ()
+  
 /// If Alice thinks she talks with Bob,
 /// then Bob thinks he talk to Alice (with the same nonces),
 /// unless the attacker corrupted Alice or Bob.
 
 val responder_authentication:
-  tr:trace -> i:timestamp ->
-  alice:principal -> bob:principal -> n_a:bytes -> n_b:bytes ->
+  tr:trace -> ts:timestamp ->
+  alice:principal -> sid:state_id ->
+  bob:principal -> n_a:bytes -> n_b:bytes ->
   Lemma
   (requires
-    state_was_set_some_id tr alice (InitiatorSendingMsg3 bob n_a n_b) /\
+    state_was_set_at tr ts alice sid (InitiatorSendingMsg3 bob n_a n_b) /\
     trace_invariant tr
   )
   (ensures
     is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob) \/
-    state_was_set_some_id tr bob (ResponderSendingMsg2 alice n_a n_b)
+    state_was_set_some_id (prefix tr ts) bob (ResponderSendingMsg2 alice n_a n_b)
   )
-let responder_authentication tr i alice bob n_a n_b = ()
+let responder_authentication tr i alice sid bob n_a n_b = ()
 
 /// The nonce n_a is unknown to the attacker,
 /// unless the attacker corrupted Alice or Bob.


### PR DESCRIPTION
I strengthened the authentication properties to get them closer to the intuition of the properties:
in the previous version, we just had `state_was_set the_other_principal state`.
However, in the original version using events (also in the properties), we had the stronger `event_triggered (prefix tr i)` for `i` being the timestamp of the first event.
With these changes, we get the same "prefix" guarantee for the state based formulation of the properties.

Note that the invariants and proofs of the protocols did not change,
just the property statement and the necessary lemmas for the state equivalent of `event_triggered_at` (`state_was_set_at`).