### PR TITLE
Simplify online secrecy

### DIFF
--- a/dy-extensions/DY.Simplified.fst
+++ b/dy-extensions/DY.Simplified.fst
@@ -12,6 +12,8 @@ let gen_rand =
 let gen_rand_labeled l =
     mk_rand NoUsage l 32
 
+let principal_is_corrupt tr prin = is_corrupt tr (principal_label prin)
+
 val start_new_session:
   #a:Type -> {| local_state a |} ->
   principal -> a ->

--- a/examples/Online_with_secrecy/DY.OnlineS.Data.fst
+++ b/examples/Online_with_secrecy/DY.OnlineS.Data.fst
@@ -111,7 +111,7 @@ instance parseable_serializeable_bytes_state_t: parseable_serializeable bytes st
 /// so that they are distinguishable from any internal DY* states. 
 
 instance local_state_state: local_state state_t = {
-  tag = "P.State";
+  tag = "Online.State";
   format = parseable_serializeable_bytes_state_t;
 }
 
@@ -119,21 +119,8 @@ instance local_state_state: local_state state_t = {
 
 (*** PKI ***)
 
-/// For en-/de-cryption we assume some PKI.
-/// I.e., every participant has some private decryption keys
-/// and some public encryption keys from other participants.
-/// All private keys of a participant will be stored in one session
-/// and all public keys that the participant knows will be stored in another session.
-/// For each participant, we collect both these session IDs in a global record.
-
-type global_sess_ids = {
-  pki: state_id;
-  private_keys: state_id;
-}
-
 /// Similarly as for states,
 /// we tag the keys that are used on the protocol level,
 /// so that they can not be confused with other keys.
-/// (TODO: rephrase this)
 
-let key_tag = "P.Key"
+let key_tag = "Online.Key"

--- a/examples/Online_with_secrecy/DY.OnlineS.Invariants.fst
+++ b/examples/Online_with_secrecy/DY.OnlineS.Invariants.fst
@@ -197,6 +197,8 @@ instance protocol_invariants_p: protocol_invariants = {
 }
 
 
+let complies_with_online_protocol tr = trace_invariant #protocol_invariants_p tr
+
 (*** Helper Lemmas for the Secrecy Proof ***)
 
 // TODO: Can all of this be hidden somehow?

--- a/examples/Online_with_secrecy/DY.OnlineS.Protocol.fst
+++ b/examples/Online_with_secrecy/DY.OnlineS.Protocol.fst
@@ -10,7 +10,7 @@ open DY.Extend
 open DY.OnlineS.Data
 
 /// Here we define the DY* mode of the "Online?" protocol,
-/// an extension of the simple Two Message protocol:
+/// an extension of the simple Two-Message protocol:
 /// the two messages are now (asymmetrically) encrypted
 ///
 /// A -> B: enc{Ping (A, n_A)}_B
@@ -18,7 +18,7 @@ open DY.OnlineS.Data
 ///
 /// The model consists of 3 functions,
 /// one for each protocol step
-/// (just as for the simple two message protocol):
+/// (just as for the simple Two-Message protocol):
 /// 1. Alice sends the Ping to Bob (`send_ping`)
 /// 2. Bob receives the Ping and replies with the Ack (`receive_ping_and_send_ack`)
 /// 3. Alice receives the Ack (`receive_ack`)
@@ -42,14 +42,14 @@ open DY.OnlineS.Data
 let nonce_label alice bob = join (principal_label alice) (principal_label bob)
 
 val send_ping: principal -> principal -> state_id -> traceful (option (state_id & timestamp))
-let send_ping alice bob keys_sid =
+let send_ping alice bob alice_public_keys_sid =
   // TODO: explain high-level idea of "intended readers"
   let* n_a = gen_rand_labeled (nonce_label alice bob) in
   
   let ping = Ping {alice; n_a} in 
 
   // encrypt the message for bob
-  let*? ping_encrypted = pke_enc_for alice bob keys_sid key_tag ping in
+  let*? ping_encrypted = pke_enc_for alice bob alice_public_keys_sid key_tag ping in
   let* msg_ts = send_msg ping_encrypted in
 
   let ping_state = SentPing {bob; n_a} in
@@ -72,7 +72,7 @@ let send_ping alice bob keys_sid =
 /// The step fails, if one of
 /// * decryption fails
 /// * the message is not of the right type, i.e., not a first message
-/// * encryption fails
+/// * encryption fails (for example, if Bob doesn't have a public key for Alice)
 
 /// Decrypting the message (Step 2 from above) is pulled out to a separate function
 /// The function
@@ -82,11 +82,11 @@ let send_ping alice bob keys_sid =
 /// The function fails if decryption fails.
 
 val decode_ping : principal -> state_id -> bytes -> traceful (option ping_t)
-let decode_ping bob keys_sid msg =
+let decode_ping bob bob_private_keys_sid msg =
   // try to decrypt the message with
   // a private key of bob with the protocol tag
   // (fails, if no such key exists)
-  let*? png = pke_dec_with_key_lookup #message_t bob keys_sid key_tag msg in
+  let*? png = pke_dec_with_key_lookup #message_t bob bob_private_keys_sid key_tag msg in
   
   // check that the decrypted message is of the right type
   // (otherwise fail)
@@ -98,21 +98,22 @@ let decode_ping bob keys_sid msg =
 
 /// Now the actual receive and reply step
 /// using the decode function
-val receive_ping_and_send_ack: principal -> global_sess_ids -> timestamp -> traceful (option (state_id & timestamp))
-let receive_ping_and_send_ack bob global_sids msg_ts =
+val receive_ping_and_send_ack: principal -> state_id -> state_id -> timestamp -> traceful (option (state_id & timestamp))
+let receive_ping_and_send_ack bob bob_private_keys_sid bob_public_keys_sid msg_ts =
   let*? msg = recv_msg msg_ts in
   // decode the received expected ping
-  let*? png = decode_ping bob global_sids.private_keys msg in
+  let*? png = decode_ping bob bob_private_keys_sid msg in
 
-  let n_a = png.n_a in
   let alice = png.alice in
+  let n_a = png.n_a in
 
   let ack = Ack {n_a} in
   // encrypt the reply for alice
-  let*? ack_encrypted = pke_enc_for bob alice global_sids.pki key_tag ack in
+  let*? ack_encrypted = pke_enc_for bob alice bob_public_keys_sid key_tag ack in
   let* ack_ts = send_msg ack_encrypted in
-  
-  let* sess_id = start_new_session bob (SentAck {alice; n_a}) in
+
+  let ack_state = SentAck {alice; n_a} in
+  let* sess_id = start_new_session bob ack_state in
   
   return (Some (sess_id, ack_ts))
 
@@ -139,10 +140,10 @@ let receive_ping_and_send_ack bob global_sids msg_ts =
 /// Fails if decryption fails.
 
 val decode_ack : principal -> state_id -> bytes -> traceful (option ack_t)
-let decode_ack alice keys_sid cipher =
+let decode_ack alice alice_private_keys_sid cipher =
   // try to decrypt the message with
   // a private key of alice with the protocol tag
-  let*? ack = pke_dec_with_key_lookup #message_t alice keys_sid key_tag cipher in
+  let*? ack = pke_dec_with_key_lookup #message_t alice alice_private_keys_sid key_tag cipher in
 
   // check that the decrypted message is of the Ack type
   guard_tr (Ack? ack);*?
@@ -152,16 +153,18 @@ let decode_ack alice keys_sid cipher =
 
 /// The actual protocol step using the decode function
 val receive_ack: principal -> state_id -> timestamp -> traceful (option state_id)
-let receive_ack alice keys_sid ack_ts =
+let receive_ack alice alice_private_keys_sid ack_ts =
   let*? msg = recv_msg ack_ts in
   // decode the received expected ack
-  let*? ack = decode_ack alice keys_sid msg in
+  let*? ack = decode_ack alice alice_private_keys_sid msg in
 
   let n_a = ack.n_a in
 
   let*? (st, sid) = lookup_state #state_t alice
-    (fun st -> SentPing? st && (SentPing?.ping st).n_a = n_a)
-    in
+    (fun st -> 
+          SentPing? st
+      && (SentPing?.ping st).n_a = n_a
+    ) in
   guard_tr(SentPing? st);*?
   let bob = (SentPing?.ping st).bob in
 

--- a/examples/Online_with_secrecy/DY.OnlineS.Run.Printing.fst
+++ b/examples/Online_with_secrecy/DY.OnlineS.Run.Printing.fst
@@ -4,6 +4,8 @@ open DY.Core
 open DY.Lib
 open Comparse
 
+open DY.Simplified
+
 open DY.OnlineS.Data
 
 /// Helper functions for trace printing.
@@ -32,5 +34,5 @@ val get_trace_to_string_printers: trace_to_string_printers
 let get_trace_to_string_printers  = 
   trace_to_string_printers_builder 
     message_to_string
-    [(local_state_state.tag, state_to_string)]
+    ((local_state_state.tag, state_to_string) :: default_state_to_string)
     []

--- a/examples/Online_with_secrecy/DY.OnlineS.Run.fst
+++ b/examples/Online_with_secrecy/DY.OnlineS.Run.fst
@@ -3,6 +3,8 @@ module DY.OnlineS.Run
 open DY.Core
 open DY.Lib
 
+open DY.Simplified
+
 open DY.OnlineS.Run.Printing
 open DY.OnlineS.Data
 open DY.OnlineS.Protocol
@@ -23,52 +25,33 @@ let run () : traceful (option unit ) =
 
   // Initialize key storage for Alice
   // private and public keys are stored in separate sessions
-  let* alice_priv_keys_sid = initialize_private_keys alice in
-  let* alice_pub_keys_sid = initialize_pki alice in
-  // we collect both session ids in a global record
-  let alice_global_session_ids : global_sess_ids = 
-    { pki = alice_pub_keys_sid; 
-      private_keys = alice_priv_keys_sid
-    } in
+  let* alice_private_keys_sid = initialize_private_keys alice in
+  let* alice_public_keys_sid = initialize_pki alice in
 
   // Initialize key storage for Bob
-  let* bob_priv_keys_sid = initialize_private_keys bob in
-  let* bob_pub_keys_sid = initialize_pki bob in  
-  let bob_global_session_ids: global_sess_ids = 
-    { pki = bob_pub_keys_sid; 
-      private_keys = bob_priv_keys_sid
-    } in
+  let* bob_private_keys_sid = initialize_private_keys bob in
+  let* bob_public_keys_sid = initialize_pki bob in  
 
   // Generate private key for Alice and store it in her private keys session
-  generate_private_key alice alice_global_session_ids.private_keys (LongTermPkeKey key_tag);*
+  generate_private_pke_key alice alice_private_keys_sid key_tag;*
   
   // Generate private key for Bob and store it in his private keys session
-  generate_private_key bob bob_global_session_ids.private_keys (LongTermPkeKey key_tag);*
+  generate_private_pke_key bob bob_private_keys_sid key_tag;*
 
   // Store Bob's public key in Alice's state
-  // Bob's public key is computed from his private key
-  // 1. Retrieve Bob's private key from his private key session
-  // 2. Compute the public key from the private key
-  // 3. Install Bob's public key in Alice's public key store
-  let*? priv_key_bob = get_private_key bob bob_global_session_ids.private_keys (LongTermPkeKey key_tag) in
-  let pub_key_bob = pk priv_key_bob in
-  install_public_key alice alice_global_session_ids.pki (LongTermPkeKey key_tag) bob pub_key_bob;*
+  install_public_pke_key alice alice_public_keys_sid key_tag bob bob_private_keys_sid;*
 
-  // Store Alice's public key in Bob's state in the same way
-  let*? priv_key_alice = get_private_key alice alice_global_session_ids.private_keys (LongTermPkeKey key_tag) in
-  let pub_key_alice = pk priv_key_alice in
-  install_public_key bob bob_global_session_ids.pki (LongTermPkeKey key_tag) alice pub_key_alice;*
-
-
+  // Store Alice's public key in Bob's state
+  install_public_pke_key bob bob_public_keys_sid key_tag alice alice_private_keys_sid;*
 
   (*** The actual protocol run ***)
 
   // Alice sends a Ping to Bob
-  let*? (alice_sid, ping_ts) = send_ping alice bob alice_global_session_ids.pki in
+  let*? (alice_sid, ping_ts) = send_ping alice bob alice_public_keys_sid in
   // Bob replies with an Ack (reading the ping at the given timestamp)
-  let*? (bob_sid, ack_ts) = receive_ping_and_send_ack bob bob_global_session_ids ping_ts in
+  let*? (bob_sid, ack_ts) = receive_ping_and_send_ack bob bob_private_keys_sid bob_public_keys_sid ping_ts in
   // Alice receives the Ack (at the given ack timestamp)
-  let*? _ = receive_ack alice alice_global_session_ids.private_keys ack_ts in
+  receive_ack alice alice_private_keys_sid ack_ts;*?
 
 
  (*** Printing the Trace ***)

--- a/examples/Online_with_secrecy/DY.OnlineS.Secrecy.fst
+++ b/examples/Online_with_secrecy/DY.OnlineS.Secrecy.fst
@@ -30,8 +30,7 @@ val n_a_secrecy:
   tr:trace -> alice:principal -> bob:principal -> n_a:bytes ->
   Lemma
   (requires
- //   attacker_knows tr n_a /\
-    trace_invariant tr /\ (
+      complies_with_online_protocol tr /\ (
       (state_was_set_some_id tr alice (SentPing {bob; n_a})) \/
       (state_was_set_some_id tr alice (ReceivedAck {bob; n_a} ))
     )
@@ -39,6 +38,8 @@ val n_a_secrecy:
   (ensures
      attacker_knows tr n_a ==>
      principal_is_corrupt tr alice \/ principal_is_corrupt tr bob
+     // You can also use the equivalent formulation:
+     // ~(principal_is_corrupt tr alice \/ principal_is_corrupt tr bob) ==> ~(attacker_knows tr n_a)
   )
 
 /// The proof idea is the following:

--- a/examples/Online_with_secrecy/DY.OnlineS.Secrecy.fst
+++ b/examples/Online_with_secrecy/DY.OnlineS.Secrecy.fst
@@ -3,6 +3,8 @@ module DY.OnlineS.Secrecy
 open Comparse
 open DY.Core
 open DY.Lib
+open DY.Simplified
+open DY.Extend
 
 open DY.OnlineS.Data
 open DY.OnlineS.Invariants
@@ -28,13 +30,16 @@ val n_a_secrecy:
   tr:trace -> alice:principal -> bob:principal -> n_a:bytes ->
   Lemma
   (requires
-    attacker_knows tr n_a /\
+ //   attacker_knows tr n_a /\
     trace_invariant tr /\ (
-      (exists sess_id. state_was_set tr alice sess_id (SentPing {bob; n_a})) \/
-      (exists sess_id. state_was_set tr alice sess_id (ReceivedAck {bob; n_a} ))
+      (state_was_set_some_id tr alice (SentPing {bob; n_a})) \/
+      (state_was_set_some_id tr alice (ReceivedAck {bob; n_a} ))
     )
   )
-  (ensures is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob))
+  (ensures
+     attacker_knows tr n_a ==>
+     principal_is_corrupt tr alice \/ principal_is_corrupt tr bob
+  )
 
 /// The proof idea is the following:
 /// For any nonce stored in one of Alice's states (SentPing or ReceivedAck)
@@ -47,4 +52,6 @@ val n_a_secrecy:
 /// The proof thus only consists of calling the main attacker lemma
 /// `attacker_only_knows_publishable_values`.
 let n_a_secrecy tr alice bob n_a =
-  attacker_only_knows_publishable_values tr n_a
+  introduce attacker_knows tr n_a ==> principal_is_corrupt tr alice \/ principal_is_corrupt tr bob
+  with _ . 
+    attacker_only_knows_publishable_values tr n_a

--- a/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -102,6 +102,8 @@ instance protocol_invariants_nsl: protocol_invariants = {
   trace_invs = trace_invariants_nsl;
 }
 
+let complies_with_nsl tr = trace_invariant #protocol_invariants_nsl tr
+
 /// Lemmas that the global state predicate contains all the local ones
 
 // Below, the `has_..._predicate` are called with the implicit argument `#protocol_invariants_nsl`.

--- a/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.SecurityProperties.fst
+++ b/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.SecurityProperties.fst
@@ -27,12 +27,12 @@ val initiator_authentication:
   alice:principal -> bob:principal -> n_a:bytes -> n_b:bytes ->
   Lemma
   (requires
-    state_was_set_some_id tr bob (ResponderReceivedMsg3 alice n_a n_b) /\
-    trace_invariant tr
+    complies_with_nsl tr /\
+    state_was_set_some_id tr bob (ResponderReceivedMsg3 alice n_a n_b)
   )
   (ensures
     principal_is_corrupt tr alice \/ principal_is_corrupt tr bob \/
-  state_was_set_some_id tr alice (InitiatorSendingMsg1 bob n_a)
+    state_was_set_some_id tr alice (InitiatorSendingMsg1 bob n_a)
   )
 let initiator_authentication tr i alice bob n_a n_b = ()
 
@@ -45,8 +45,8 @@ val responder_authentication:
   alice:principal -> bob:principal -> n_a:bytes -> n_b:bytes ->
   Lemma
   (requires
-    state_was_set_some_id tr alice (InitiatorSendingMsg3 bob n_a n_b) /\
-    trace_invariant tr
+    complies_with_nsl tr /\
+    state_was_set_some_id tr alice (InitiatorSendingMsg3 bob n_a n_b)
   )
   (ensures
     principal_is_corrupt tr alice \/ principal_is_corrupt tr bob \/
@@ -61,8 +61,8 @@ val n_a_secrecy:
   tr:trace -> alice:principal -> bob:principal -> n_a:bytes ->
   Lemma
   (requires
-    attacker_knows tr n_a /\
-    trace_invariant tr /\ (
+    complies_with_nsl tr /\ 
+    attacker_knows tr n_a /\ (
       (state_was_set_some_id tr alice (InitiatorSendingMsg1 bob n_a)) \/
       (exists n_b. state_was_set_some_id tr alice (InitiatorSendingMsg3 bob n_a n_b)) \/
       (exists n_b. state_was_set_some_id tr bob (ResponderReceivedMsg3 alice n_a n_b))
@@ -79,8 +79,8 @@ val n_b_secrecy:
   tr:trace -> alice:principal -> bob:principal -> n_b:bytes ->
   Lemma
   (requires
-    attacker_knows tr n_b /\
-    trace_invariant tr /\ (
+    complies_with_nsl tr /\
+    attacker_knows tr n_b /\ (
       (exists n_a. state_was_set_some_id tr bob (ResponderSendingMsg2 alice n_a n_b)) \/
       (exists n_a. state_was_set_some_id tr bob (ResponderReceivedMsg3 alice n_a n_b)) \/
       (exists n_a. state_was_set_some_id tr alice (InitiatorSendingMsg3 bob n_a n_b))

--- a/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.SecurityProperties.fst
+++ b/examples/nsl_pk_only_one_event_lookup/DY.Example.NSL.SecurityProperties.fst
@@ -3,6 +3,7 @@ module DY.Example.NSL.SecurityProperties
 open Comparse
 open DY.Core
 open DY.Lib
+open DY.Simplified
 open DY.Example.NSL.Protocol.Total.Proof
 open DY.Example.NSL.Protocol.Stateful
 open DY.Example.NSL.Protocol.Stateful.Proof
@@ -30,7 +31,7 @@ val initiator_authentication:
     trace_invariant tr
   )
   (ensures
-    is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob) \/
+    principal_is_corrupt tr alice \/ principal_is_corrupt tr bob \/
   state_was_set_some_id tr alice (InitiatorSendingMsg1 bob n_a)
   )
 let initiator_authentication tr i alice bob n_a n_b = ()
@@ -48,7 +49,7 @@ val responder_authentication:
     trace_invariant tr
   )
   (ensures
-    is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob) \/
+    principal_is_corrupt tr alice \/ principal_is_corrupt tr bob \/
     state_was_set_some_id tr bob (ResponderSendingMsg2 alice n_a n_b)
   )
 let responder_authentication tr i alice bob n_a n_b = ()
@@ -62,12 +63,12 @@ val n_a_secrecy:
   (requires
     attacker_knows tr n_a /\
     trace_invariant tr /\ (
-      (exists sess_id. state_was_set tr alice sess_id (InitiatorSendingMsg1 bob n_a)) \/
-      (exists sess_id n_b. state_was_set tr alice sess_id (InitiatorSendingMsg3 bob n_a n_b)) \/
-      (exists sess_id n_b. state_was_set tr bob sess_id (ResponderReceivedMsg3 alice n_a n_b))
+      (state_was_set_some_id tr alice (InitiatorSendingMsg1 bob n_a)) \/
+      (exists n_b. state_was_set_some_id tr alice (InitiatorSendingMsg3 bob n_a n_b)) \/
+      (exists n_b. state_was_set_some_id tr bob (ResponderReceivedMsg3 alice n_a n_b))
     )
   )
-  (ensures is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob))
+  (ensures principal_is_corrupt tr alice \/ principal_is_corrupt tr bob)
 let n_a_secrecy tr alice bob n_a =
   attacker_only_knows_publishable_values tr n_a
 
@@ -80,11 +81,11 @@ val n_b_secrecy:
   (requires
     attacker_knows tr n_b /\
     trace_invariant tr /\ (
-      (exists sess_id n_a. state_was_set tr bob sess_id (ResponderSendingMsg2 alice n_a n_b)) \/
-      (exists sess_id n_a. state_was_set tr bob sess_id (ResponderReceivedMsg3 alice n_a n_b)) \/
-      (exists sess_id n_a. state_was_set tr alice sess_id (InitiatorSendingMsg3 bob n_a n_b))
+      (exists n_a. state_was_set_some_id tr bob (ResponderSendingMsg2 alice n_a n_b)) \/
+      (exists n_a. state_was_set_some_id tr bob (ResponderReceivedMsg3 alice n_a n_b)) \/
+      (exists n_a. state_was_set_some_id tr alice (InitiatorSendingMsg3 bob n_a n_b))
     )
   )
-  (ensures is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob))
+  (ensures principal_is_corrupt tr alice \/ principal_is_corrupt tr bob)
 let n_b_secrecy tr alice bob n_b =
   attacker_only_knows_publishable_values tr n_b


### PR DESCRIPTION
I simplified the proof and properties of nonce secrecy for the Online? protocol.
In particular, 
* I removed the `global_sess_ids` and instead have the private and public key sids explictly.
* new functions for key generation hiding the `LongTermPkeKey` constructors.
* a simplified `principal_is_corrupt` for `is_corrupt (principal_label ... )`
(Includes also adaptions of the nonce secrecy property for NSL)
